### PR TITLE
child instance

### DIFF
--- a/src/app/routers/protected/user_instance_router.ts
+++ b/src/app/routers/protected/user_instance_router.ts
@@ -370,7 +370,12 @@ router.put(
       // event task configuration
       const eventTask = {
         autoStart: toBoolean(config.eventTask?.autoStart),
-        autoRestart: toBoolean(config.eventTask?.autoRestart)
+        autoRestart: toBoolean(config.eventTask?.autoRestart),
+        childInstance: config.eventTask?.childInstance,
+        childInstanceStart: toBoolean(config.eventTask?.childInstanceStart),
+        childInstanceStop: toBoolean(config.eventTask?.childInstanceStop),
+        childInstanceRestart: toBoolean(config.eventTask?.childInstanceRestart),
+
       };
 
       // web terminal settings


### PR DESCRIPTION
✨New Feature✨

Add child instance in `eventTask` of instance

By setting child instance, you can start/stop/restart child instance when the parent instance start/stop/restart

---

✨新特性✨

在实例的 `事件任务` 中添加子实例

通过设置子实例，可以在父实例 启动/停止/重启 时同时 启动/停止/重启 子实例