### PR TITLE
Fix: remote time rendered using remote time zone (#776)

### DIFF
--- a/src/app/routers/private/overview_router.ts
+++ b/src/app/routers/private/overview_router.ts
@@ -58,7 +58,7 @@ router.get("/", permission({ level: 10, token: false }), async (ctx) => {
     },
     system: {
       user: os.userInfo(),
-      time: new Date().toLocaleString(),
+      time: new Date().getTime(),
       totalmem: selfInfo.totalmem,
       freemem: selfInfo.freemem,
       type: selfInfo.type,


### PR DESCRIPTION
问题详见 (Issue #776)

目前请求overall传回的是时间戳，到本地转换为字符串的。