### PR TITLE
修复: WS连接时使用 data/RemoteServiceConfig 中的 connectOpts

### DIFF
--- a/src/app/entity/remote_service.ts
+++ b/src/app/entity/remote_service.ts
@@ -44,7 +44,7 @@ export default class RemoteService {
     }
 
     logger.info(`${$t("daemonInfo.tryConnect")}:${daemonInfo}`);
-    this.socket = io(addr, connectOpts);
+    this.socket = io(addr, this.config.connectOpts);
 
     // register built-in events
     this.socket.on("connect", async () => {


### PR DESCRIPTION
在使用自签名证书时发现 web 端无法连接到 daemon，确认了问题和 #857 应该是一样的，但是在 data/RemoteServiceConfig 有看到 rejectUnauthorized 的配置，本地debug后确认为使用未赋值的 connectOpts 进行了 ws 连接，因 this.config.connectOpts 为配置信息里存在的 connectOps 且 src/app/entity/remote_service.ts:27 行也判断了 connectOpts 不为 undefined 的话会将其赋值给 this.config.connectOpts ，此处修改为  this.socket = io(addr, this.config.connectOpts);

ps: 看到 RemoteServiceConfig 中默认 rejectUnauthorized 配置为 false ，个人建议默认为 true (安全起见)，文档中可加说明如果使用自签名或不安全的证书自行前往配置文件修改