### PR TITLE
Fix: Typo `donwload`

### DIFF
--- a/src/app/entity/setting.ts
+++ b/src/app/entity/setting.ts
@@ -19,7 +19,7 @@ export default class SystemConfig {
   // Maximum simultaneous compression tasks
   maxCompress: number = 1;
   // Maximum simultaneous download tasks
-  maxDonwload: number = 10;
+  maxDownload: number = 10;
   // Decompression implementation form
   zipType: number = 1;
   // Login times IP limit

--- a/src/app/routers/private/settings_router.ts
+++ b/src/app/routers/private/settings_router.ts
@@ -27,7 +27,7 @@ router.put("/setting", validator({ body: {} }), permission({ level: 10 }), async
     if (config.crossDomain != null) systemConfig.crossDomain = config.crossDomain;
     if (config.gzip != null) systemConfig.gzip = config.gzip;
     if (config.maxCompress != null) systemConfig.maxCompress = config.maxCompress;
-    if (config.maxDonwload != null) systemConfig.maxDonwload = config.maxDonwload;
+    if (config.maxDownload != null) systemConfig.maxDownload = config.maxDownload;
     if (config.zipType != null) systemConfig.zipType = config.zipType;
     if (config.loginCheckIp != null) systemConfig.loginCheckIp = config.loginCheckIp;
     if (config.forwardType != null) systemConfig.forwardType = Number(config.forwardType);


### PR DESCRIPTION
Fix: https://github.com/MCSManager/MCSManager/issues/947
修复Donwload的拼写错误