### PR TITLE
Fix: 当有配置prefix的时候面包屑跳转错误

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -79,7 +79,7 @@ const breadcrumbs = computed(() => {
     {
       title: t("TXT_CODE_f5b9d58f"),
       disabled: false,
-      href: "/"
+      href: `.`
     }
   ];
 
@@ -93,7 +93,7 @@ const breadcrumbs = computed(() => {
       arr.push({
         title: v.name,
         disabled: false,
-        href: `/#${v.path}${params}`
+        href: `./#${v.path}${params}`
       });
     });
   }
@@ -101,7 +101,7 @@ const breadcrumbs = computed(() => {
   arr.push({
     title: String(route.name),
     disabled: true,
-    href: `/#${route.fullPath}`
+    href: `./#${route.fullPath}`
   });
 
   return arr;


### PR DESCRIPTION
如果用户在config.json配置了prefix后，点击面包屑跳转的时候，会跳转错误