### PR TITLE
Fix(frontend): use modal to confirm delete user instead of pop-confirm

### DIFF
--- a/frontend/src/widgets/UserList.vue
+++ b/frontend/src/widgets/UserList.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from "vue";
 import { t } from "@/lang/i18n";
-import { message, type FormInstance } from "ant-design-vue";
+import { message, Modal, type FormInstance } from "ant-design-vue";
 import { DownOutlined, UserOutlined, SearchOutlined } from "@ant-design/icons-vue";
 import type { Rule } from "ant-design-vue/es/form";
 import { throttle } from "lodash";
@@ -162,6 +162,15 @@ const handleBatchDelete = async () => {
     return message.warn(t("TXT_CODE_d78ad17a"));
   }
   await deleteUser(selectedUsers.value);
+};
+
+const showDeleteConfirm = (user: BaseUserInfo) => {
+  Modal.confirm({
+    title: () => t('TXT_CODE_e99ab99a'),
+    okType: 'danger',
+    onOk: () => handleDeleteUser(user),
+    maskClosable: true
+  });
 };
 
 const isAddMode = ref(true);
@@ -453,14 +462,9 @@ onMounted(async () => {
                           <a-menu-item key="2" @click="handleToUserResources(record)">
                             {{ t("TXT_CODE_4d934e3a") }}
                           </a-menu-item>
-                          <a-popconfirm
-                            :title="t('TXT_CODE_e99ab99a')"
-                            @confirm="handleDeleteUser(record)"
-                          >
-                            <a-menu-item key="3">
-                              {{ t("TXT_CODE_ecbd7449") }}
-                            </a-menu-item>
-                          </a-popconfirm>
+                          <a-menu-item key="3" @click="showDeleteConfirm(record)">
+                            {{ t("TXT_CODE_ecbd7449") }}
+                          </a-menu-item>
                         </a-menu>
                       </template>
                       <a-button size="large">


### PR DESCRIPTION
## Title: Fix(frontend): use modal to confirm delete user instead of pop-confirm

### Files changed:
* `frontend\src\widgets\UserList.vue`

### Motivation
The original `pop-confirm` component wraps the `menu-item`, causing its display position to be offset from the user record and move with the page scrolling, making it easy to delete user wrongly. The easiest way is to use `modal` for confirmation instead.

原有的 `pop-confirm` 组件包裹 `menu-item`，导致其显示位置会限制在选中用户的该行下方、且会随页面滑动而移动，容易删错用户，最简单的方法是改用 `modal` 进行确认