### PR TITLE
feat: compatibility with other docker clients

### DIFF
--- a/daemon/src/entity/commands/docker/docker_pull.ts
+++ b/daemon/src/entity/commands/docker/docker_pull.ts
@@ -2,9 +2,10 @@ import Docker from "dockerode";
 import Instance from "../../instance/instance";
 import InstanceCommand from "../base/command";
 import { t } from "i18next";
+import { DefaultDocker } from "../../../service/docker_service"
 
 export async function checkImage(name: string) {
-  const docker = new Docker();
+  const docker = new DefaultDocker();
   try {
     const image = docker.getImage(name);
     const info = await image.inspect();
@@ -56,7 +57,7 @@ export default class DockerPullCommand extends InstanceCommand {
     if (await checkImage(imageName)) return;
 
     try {
-      const docker = new Docker();
+      const docker = new DefaultDocker();
       instance.println("CONTAINER", t("TXT_CODE_2fa46b8c") + imageName);
       instance.asynchronousTask = this;
 

--- a/daemon/src/service/docker_process_service.ts
+++ b/daemon/src/service/docker_process_service.ts
@@ -2,6 +2,7 @@ import { t } from "i18next";
 import { commandStringToArray } from "../entity/commands/base/command_parser";
 import DockerPullCommand from "../entity/commands/docker/docker_pull";
 import Instance from "../entity/instance/instance";
+import { DefaultDocker } from "./docker_service"
 
 import path from "path";
 import { $t } from "../i18n";
@@ -133,7 +134,7 @@ export class SetupDockerContainer extends AsyncTask {
     logger.info("----------------");
 
     // Start Docker container creation and running
-    const docker = new Docker();
+    const docker = new DefaultDocker();
     this.container = await docker.createContainer({
       name: containerName,
       Hostname: containerName,

--- a/daemon/src/service/docker_service.ts
+++ b/daemon/src/service/docker_service.ts
@@ -1,5 +1,15 @@
 import Docker from "dockerode";
 
+export class DefaultDocker extends Docker {
+  public static readonly defaultConfig: Docker.DockerOptions = {
+    socketPath: process.env.DOCKER_HOST ?? '/var/run/docker.sock'
+  };
+
+  constructor(p?: Docker.DockerOptions) {
+    super(Object.assign(p ?? {}, DefaultDocker.defaultConfig));
+  }
+}
+
 export class DockerManager {
   // 1=creating 2=creating completed -1=creating error
   public static readonly builderProgress = new Map<string, number>();
@@ -7,7 +17,7 @@ export class DockerManager {
   public docker: Docker;
 
   constructor(p?: any) {
-    this.docker = new Docker(p);
+    this.docker = new DefaultDocker(p);
   }
 
   public getDocker() {

--- a/frontend/src/widgets/instance/dialogs/InstanceDetail.vue
+++ b/frontend/src/widgets/instance/dialogs/InstanceDetail.vue
@@ -68,11 +68,6 @@ const UPDATE_CMD_TEMPLATE =
   t("TXT_CODE_61ca492b") +
   `"C:/SteamCMD/steamcmd.exe" +login anonymous +force_install_dir "{mcsm_workspace}" "+app_update 380870 validate" +quit`;
 
-const openDialog = () => {
-  open.value = true;
-  initFormDetail();
-};
-
 const initFormDetail = () => {
   if (props.instanceInfo) {
     options.value = {
@@ -150,6 +145,12 @@ const loadNetworkModes = async () => {
   } catch (err: any) {
     return reportErrorMsg(err.message);
   }
+};
+
+const openDialog = async () => {
+  open.value = true;
+  initFormDetail();
+  await awaitPromise.all([loadImages(), loadNetworkModes()]);
 };
 
 const rules: Record<string, Rule[]> = {

--- a/frontend/src/widgets/instance/dialogs/InstanceDetail.vue
+++ b/frontend/src/widgets/instance/dialogs/InstanceDetail.vue
@@ -150,7 +150,7 @@ const loadNetworkModes = async () => {
 const openDialog = async () => {
   open.value = true;
   initFormDetail();
-  await awaitPromise.all([loadImages(), loadNetworkModes()]);
+  await Promise.all([loadImages(), loadNetworkModes()]);
 };
 
 const rules: Record<string, Rule[]> = {


### PR DESCRIPTION
This PR is part of a overall plan that makes MCSManager securer by eliminating root access.

[Podman](https://podman.io) is another implementation to the CNI standards used by Docker. It is nearly a drop-in replacement of Docker while providing support to rootless containers. This would make it possible to eliminate the use of root user while still being able to provide containerized access.

To support podman, one must specify the socket `$XDG_RUNTIME_DIR/podman/podman.sock`, instead of `/var/run/docker.sock` which is by default used by dockerode. This PR allows all calls to dockerode to respect the value of `DOCKER_HOST` like docker-cli, and slightly adjusts UI refresh logics to support heterogenous container runtime implementations.