### PR TITLE
feat: daemon内置java运行时

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,11 +5,8 @@ on:
     types: [published]
 
 jobs:
-  build:
+  build-web:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java_version: [8, 11, 17, 21]
 
     steps:
       - uses: actions/checkout@v4
@@ -21,6 +18,40 @@ jobs:
           images: |
             name=ghcr.io/${{ github.repository }}-web
             name=githubyumao/mcsmanager-web,enable=${{ github.repository == 'MCSManager/MCSManager' }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to DockerHub
+        if: ${{ github.repository == 'MCSManager/MCSManager' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build and Push Web
+        uses: docker/build-push-action@v6
+        with:
+          file: dockerfile/web.dockerfile
+          push: true
+          tags: ${{ steps.meta_web.outputs.tags }}
+          labels: ${{ steps.meta_web.outputs.labels }}
+
+  build-daemon:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java_version: [8, 11, 17, 21]
+
+    steps:
+      - uses: actions/checkout@v4
 
       - name: Docker meta daemon
         id: meta_daemon
@@ -48,14 +79,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-
-      - name: Build and Push Web
-        uses: docker/build-push-action@v6
-        with:
-          file: dockerfile/web.dockerfile
-          push: true
-          tags: ${{ steps.meta_web.outputs.tags }}
-          labels: ${{ steps.meta_web.outputs.labels }}
 
       - name: Build and Push Daemon
         uses: docker/build-push-action@v6

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java_version: [8, 11, 17, 21]
 
     steps:
       - uses: actions/checkout@v4
@@ -24,8 +27,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            name=ghcr.io/${{ github.repository }}-daemon
-            name=githubyumao/mcsmanager-daemon
+            name=ghcr.io/${{ github.repository }}-daemon,enable=${{ matrix.java_version == 21 }}
+            name=githubyumao/mcsmanager-daemon,enable=${{ matrix.java_version == 21 }}
+            name=ghcr.io/${{ github.repository }}-daemon-jdk${{ matrix.java_version }}
+            name=githubyumao/mcsmanager-daemon-jdk${{ matrix.java_version }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -44,7 +49,7 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Build and Push Web
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           file: dockerfile/web.dockerfile
           push: true
@@ -52,9 +57,11 @@ jobs:
           labels: ${{ steps.meta_web.outputs.labels }}
 
       - name: Build and Push Daemon
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           file: dockerfile/daemon.dockerfile
           push: true
           tags: ${{ steps.meta_daemon.outputs.tags }}
           labels: ${{ steps.meta_daemon.outputs.labels }}
+          build-args: |
+            JAVA_RUNTIME=${{ matrix.java_version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           images: |
             name=ghcr.io/${{ github.repository }}-web
-            name=githubyumao/mcsmanager-web
+            name=githubyumao/mcsmanager-web,enable=${{ github.repository == 'MCSManager/MCSManager' }}
 
       - name: Docker meta daemon
         id: meta_daemon
@@ -28,9 +28,9 @@ jobs:
         with:
           images: |
             name=ghcr.io/${{ github.repository }}-daemon,enable=${{ matrix.java_version == 21 }}
-            name=githubyumao/mcsmanager-daemon,enable=${{ matrix.java_version == 21 }}
+            name=githubyumao/mcsmanager-daemon,enable=${{ github.repository == 'MCSManager/MCSManager' && matrix.java_version == 21 }}
             name=ghcr.io/${{ github.repository }}-daemon-jdk${{ matrix.java_version }}
-            name=githubyumao/mcsmanager-daemon-jdk${{ matrix.java_version }}
+            name=githubyumao/mcsmanager-daemon-jdk${{ matrix.java_version }},enable=${{ github.repository == 'MCSManager/MCSManager' }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -43,6 +43,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to DockerHub
+        if: ${{ github.repository == 'MCSManager/MCSManager' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/dockerfile/daemon.dockerfile
+++ b/dockerfile/daemon.dockerfile
@@ -1,3 +1,5 @@
+ARG EMBEDDED_JAVA_VERSION=21
+
 FROM node:lts AS builder
 
 WORKDIR /src
@@ -11,7 +13,12 @@ RUN chmod a+x ./install-dependents.sh &&\
 RUN wget --input-file=lib-urls.txt --directory-prefix=production-code/daemon/lib/ &&\
     chmod a+x production-code/daemon/lib/*
 
-FROM node:lts
+FROM eclipse-temurin:${EMBEDDED_JAVA_VERSION}-jdk
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y curl &&\
+    curl -fsSL https://deb.nodesource.com/setup_20.x | bash &&\
+    apt-get update && apt-get install -y nodejs && apt-get clean
 
 WORKDIR /opt/mcsmanager/daemon
 
@@ -25,4 +32,4 @@ ENV MCSM_INSTANCES_BASE_PATH=/opt/mcsmanager/daemon/data/InstanceData
 
 VOLUME ["/opt/mcsmanager/daemon/data", "/opt/mcsmanager/daemon/logs"]
 
-CMD [ "app.js", "--max-old-space-size=8192" ]
+CMD [ "node", "app.js", "--max-old-space-size=8192" ]

--- a/example.docker-compose.yml
+++ b/example.docker-compose.yml
@@ -12,8 +12,9 @@ services:
   daemon:
     image: githubyumao/mcsmanager-daemon:latest
     restart: unless-stopped
-    ports:
-      - "24444:24444"
+    network_mode: host # if you want run instance in daemon container
+    # ports:
+    #   - "24444:24444"
     environment:
       - MCSM_DOCKER_WORKSPACE_PATH=<CHANGE_ME_TO_INSTALL_PATH>/daemon/data/InstanceData
     volumes:


### PR DESCRIPTION
对于daemon，内置了8/11/17/21版本的Java运行时，使用 https://adoptium.net/ 此风味的OpenJDK版本，不带有`-jdk{version}`的版本指向`jdk21`
拆分了daemon和web构建
在非主仓库的GitHub Action里防止触发对Docker Hub镜像的构建以便于测试