### PR TITLE
chore: reduce web image size

### DIFF
--- a/dockerfile/daemon.dockerfile
+++ b/dockerfile/daemon.dockerfile
@@ -6,7 +6,8 @@ FROM --platform=${BUILDPLATFORM} node:lts-alpine AS builder
 WORKDIR /src
 COPY . /src
 
-RUN chmod a+x ./install-dependents.sh &&\
+RUN apk add --no-cache wget &&\
+    chmod a+x ./install-dependents.sh &&\
     chmod a+x ./build.sh &&\
     ./install-dependents.sh &&\
     ./build.sh &&\

--- a/dockerfile/daemon.dockerfile
+++ b/dockerfile/daemon.dockerfile
@@ -1,7 +1,7 @@
 ARG EMBEDDED_JAVA_VERSION=21
 ARG BUILDPLATFORM=linux/amd64
 
-FROM --platform=${BUILDPLATFORM} node:lts AS builder
+FROM --platform=${BUILDPLATFORM} node:lts-alpine AS builder
 
 WORKDIR /src
 COPY . /src
@@ -9,9 +9,8 @@ COPY . /src
 RUN chmod a+x ./install-dependents.sh &&\
     chmod a+x ./build.sh &&\
     ./install-dependents.sh &&\
-    ./build.sh
-
-RUN wget --input-file=lib-urls.txt --directory-prefix=production-code/daemon/lib/ &&\
+    ./build.sh &&\
+    wget --input-file=lib-urls.txt --directory-prefix=production-code/daemon/lib/ &&\
     chmod a+x production-code/daemon/lib/*
 
 FROM eclipse-temurin:${EMBEDDED_JAVA_VERSION}-jdk

--- a/dockerfile/web.dockerfile
+++ b/dockerfile/web.dockerfile
@@ -1,5 +1,5 @@
 ARG BUILDPLATFORM=linux/amd64
-FROM --platform=${BUILDPLATFORM} node:lts AS builder
+FROM --platform=${BUILDPLATFORM} node:lts-alpine AS builder
 
 WORKDIR /src
 COPY . /src
@@ -9,7 +9,7 @@ RUN chmod a+x ./install-dependents.sh &&\
     ./install-dependents.sh &&\
     ./build.sh
 
-FROM node:lts
+FROM node:lts-alpine
 
 WORKDIR /opt/mcsmanager/web
 


### PR DESCRIPTION
使用`node:lts-alpine`替换`node:lts`作为镜像底包
`daemon`不受影响，因为其底包使用的是`eclipse-temurin`以提供内置JDK支持