### PR TITLE
fix: prevent TypeError when handling None instance_name when querying…

### DIFF
--- a/daemon/src/routers/Instance_router.ts
+++ b/daemon/src/routers/Instance_router.ts
@@ -57,7 +57,7 @@ routerApp.on("instance/select", (ctx, data) => {
   let result = queryWrapper.select<Instance>((v) => {
     if (v.config.tag) allTags.push(...v.config.tag);
     if (InstanceSubsystem.isGlobalInstance(v)) return false;
-    if (!v.config.nickname.toLowerCase().includes(condition.instanceName.toLowerCase()))
+    if (condition.instanceName && !v.config.nickname.toLowerCase().includes(condition.instanceName.toLowerCase()))
       return false;
     if (condition.status && v.instanceStatus !== Number(condition.status)) return false;
 


### PR DESCRIPTION
## Problem Description

When accessing /api/service/remote_service_instances via HTTP GET with `instance_name=None` (it's an optional string parameter according to documentation), the server returns 500 Internal Server Error.

Upon further analysis, the problem lies in the unhandled nullable `condition.instanceName` when the queryWrapper selects instances. and throws exception when invoking `condition.instanceName.toLowerCase()`

## Solution

- add a none check before invoking `toLowerCase()`