### PR TITLE
feat(api): support listing all instances by making param.status option…

### DIFF
--- a/frontend/src/services/apis/index.ts
+++ b/frontend/src/services/apis/index.ts
@@ -90,7 +90,7 @@ export const remoteInstances = useDefineApi<
       page: number;
       page_size: number;
       instance_name?: string;
-      status: string;
+      status?: string;
       tag?: string;
     };
   },

--- a/panel/src/app/routers/daemon_router.ts
+++ b/panel/src/app/routers/daemon_router.ts
@@ -37,7 +37,7 @@ router.get(
     const page = Number(ctx.query.page);
     const pageSize = Number(ctx.query.page_size);
     const instanceName = ctx.query.instance_name;
-    const status = String(ctx.query.status);
+    const status = ctx.query.status;
     const tag = String(ctx.query.tag);
     const remoteService = RemoteServiceSubsystem.getInstance(daemonId);
     let tagList: string[] = [];


### PR DESCRIPTION
## Problem Description

The `Instance List` API doesn't support listing all instances (without any filters), but the underlying `queryWrapper.select` supports a nullable `condition.status`.

## Solution

By making `param.status` nullable, the API can support listing instances with or without filters correctly.

## P.S.

The same API has a `tag` param which is not shown on document, figured it can be shown.

Moreover, it's in singular form `tag: string`, but is expected to be a parseable string[] format, can be improved by supporting both a single string literal and a string[] parseable string? (Happy to make a PR for this if you found it reasonable)