### PR TITLE
[Security bug] Fix CNVD-C-2025-241734

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Create archive
         run: |
           mv dist_linux/ mcsmanager/
+          chmod 700 mcsmanager/web
+          chmod 700 mcsmanager/daemon
+          chmod 700 mcsmanager/
           tar czf mcsmanager_linux_release.tar.gz mcsmanager/
           rm -rf mcsmanager/
           mv dist_windows/ mcsmanager/

--- a/common/src/system_storage.ts
+++ b/common/src/system_storage.ts
@@ -48,7 +48,7 @@ export default class StorageSubsystem {
       throw new Error(`UUID ${uuid} does not conform to specification`);
     const filePath = path.join(dirPath, `${uuid}.json`);
     const data = JSON.stringify(object, null, 4);
-    fs.writeFileSync(filePath, data, { encoding: "utf-8" });
+    fs.writeFileSync(filePath, data, { encoding: "utf-8", mode: 0o600 });
   }
 
   // deep copy of the primitive type with the copy target as the prototype

--- a/daemon/src/app.ts
+++ b/daemon/src/app.ts
@@ -18,6 +18,13 @@ import "./service/async_task_service/quick_install";
 import "./service/system_visual_data";
 import { removeTrail } from "mcsmanager-common";
 
+// Fix CNVD-C-2025-241734
+try {
+  fs.chmodSync(process.cwd(), 0o700)
+} catch (e) {
+  logger.error(e)
+}
+
 initVersionManager();
 const VERSION = getVersion();
 

--- a/panel/src/app.ts
+++ b/panel/src/app.ts
@@ -19,6 +19,14 @@ import { middleware as protocolMiddleware } from "./app/middleware/protocol";
 import { mountRouters } from "./app/index";
 import versionAdapter from "./app/service/version_adapter";
 import { removeTrail } from "mcsmanager-common";
+import fs from 'fs'
+
+// Fix CNVD-C-2025-241734
+try {
+  fs.chmodSync(process.cwd(), 0o700)
+} catch (e) {
+  logger.error(e)
+}
 
 function hasParams(name: string) {
   return process.argv.includes(name);


### PR DESCRIPTION
漏洞自评：低风险（攻击者首先要进入系统的任意一个账号才能进行操作）

mcsmanager 目录以及子目录没有限制linux系统里的其它用户读取，导致系统里的其它用户可以监视敏感信息。  

daemon进程默认运行在root账号，daemon的敏感信息（包括token、终端内容）存放在data目录下，系统里的其它用户可以通过读取daemon的key然后登录daemon实现提权。


漏洞演示：（为了保护隐私，key已被替换成无效的值）
```
root@old-lenovo:~# su bddjr
bddjr@old-lenovo:/root$ cat /opt/mcsmanager/daemon/data/Config/global.json
{
    "version": 2,
    "ip": "",
    "port": 24444,
    "key": "9932a2c975e5436fb548c7b53017c57d3fd525ec61b44fc",
    "maxFileTask": 2,
    "maxZipFileSize": 60,
    "language": "zh_cn",
    "defaultInstancePath": ""
}
```

临时解决办法：用户自己运行如下命令
```
chmod 700 /opt/mcsmanager
```

临时解决办法演示：
```
root@old-lenovo:~# chmod 700 /opt/mcsmanager
root@old-lenovo:~# su bddjr
bddjr@old-lenovo:/root$ cat /opt/mcsmanager/daemon/data/Config/global.json
cat: /opt/mcsmanager/daemon/data/Config/global.json: 权限不够
```