### PR TITLE
[Security bug] Fix CNVD-C-2025-241734

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Create archive
         run: |
           mv dist_linux/ mcsmanager/
+          chmod 700 mcsmanager/web
+          chmod 700 mcsmanager/daemon
+          chmod 700 mcsmanager/
           tar czf mcsmanager_linux_release.tar.gz mcsmanager/
           rm -rf mcsmanager/
           mv dist_windows/ mcsmanager/

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Thank the following personnel for the security vulnerability patches:
 
 - [bddjr](https://github.com/bddjr)
   - CNVD-C-2025-217073 https://github.com/MCSManager/MCSManager/pull/1590  
-  - CNVD-C-2025-241734
+  - CNVD-C-2025-241734 https://github.com/MCSManager/MCSManager/pull/1599  
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -206,8 +206,9 @@ Please ensure that any submitted code adheres to our existing coding style. For 
 
 Thank the following personnel for the security vulnerability patches:
 
-[bddjr](https://github.com/bddjr)
-- https://github.com/MCSManager/MCSManager/pull/1590
+- [bddjr](https://github.com/bddjr)
+  - CNVD-C-2025-217073 https://github.com/MCSManager/MCSManager/pull/1590  
+  - CNVD-C-2025-241734
 
 <br />
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -194,8 +194,9 @@ git clone https://github.com/MCSManager/MCSManager.git
 
 感谢以下人员提供的安全漏洞补丁：
 
-[bddjr](https://github.com/bddjr)
-- https://github.com/MCSManager/MCSManager/pull/1590
+- [bddjr](https://github.com/bddjr)
+  - CNVD-C-2025-217073 https://github.com/MCSManager/MCSManager/pull/1590  
+  - CNVD-C-2025-241734
 
 
 <br />

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -196,7 +196,7 @@ git clone https://github.com/MCSManager/MCSManager.git
 
 - [bddjr](https://github.com/bddjr)
   - CNVD-C-2025-217073 https://github.com/MCSManager/MCSManager/pull/1590  
-  - CNVD-C-2025-241734
+  - CNVD-C-2025-241734 https://github.com/MCSManager/MCSManager/pull/1599  
 
 
 <br />


### PR DESCRIPTION
漏洞自评：低风险（攻击者首先要进入系统的任意一个账号才能进行操作）

mcsmanager 目录以及子目录没有限制linux系统里的其它用户读取，导致系统里的其它用户可以监视敏感信息。  

daemon进程默认运行在root账号，daemon的敏感信息（包括token、终端内容）存放在data目录下，系统里的其它用户可以通过读取daemon的key然后登录daemon实现提权。

> [!TIP]
> 即使所有者和运行环境不使用 root 权限，漏洞依旧存在，虽然攻击者可能不会获取到 root 权限，  
> 但仍然可以偷看 `/opt/mcsmanager/daemon/data/Config/global.json` 文件然后登录 daemon ，  
> 或者偷看 `/opt/mcsmanager/daemon/data/InstanceLog/` 文件夹下的所有实例输出内容。  
> 如果此时用户正好有个 `bash` 实例运行了 `su` 命令，进入了 root 权限，忘记退出了，攻击者就能趁机获得 root 权限。  
>  
> 该PR不会影响正常使用，在此前，linux 系统里的 `/opt/mcsmanager/` 文件夹的默认权限是 `755` ，即禁止 linux 系统里的其它用户写入。此后，该文件夹的默认权限是 `700` ，从而防止偷窥敏感文件。  
>  
> 当用户更新 `MCSManager` 时，如果是通过直接（运行脚本）或间接的方式解压 `mcsmanager_linux_release.tar.gz` 文件进行更新，则该漏洞会立即被修复，因为 `tar` 命令解压时会立即更改文件或文件夹的权限，无论是否存在。参考 https://github.com/bddjr/bddjr/discussions/11  

漏洞演示：  
（为了保护隐私，key已被替换成无效的值）
```
root@old-lenovo:~# su bddjr
bddjr@old-lenovo:/root$ cat /opt/mcsmanager/daemon/data/Config/global.json
{
    "version": 2,
    "ip": "",
    "port": 24444,
    "key": "9932a2c975e5436fb548c7b53017c57d3fd525ec61b44fc",
    "maxFileTask": 2,
    "maxZipFileSize": 60,
    "language": "zh_cn",
    "defaultInstancePath": ""
}
```

临时解决办法：  
用户自己在文件夹所有者的账号运行如下命令
```
chmod 700 /opt/mcsmanager
```

临时解决办法演示：
```
root@old-lenovo:~# chmod 700 /opt/mcsmanager
root@old-lenovo:~# su bddjr
bddjr@old-lenovo:/root$ cat /opt/mcsmanager/daemon/data/Config/global.json
cat: /opt/mcsmanager/daemon/data/Config/global.json: 权限不够
```

正式解决办法：  
更改 `.github/workflows/release.yml` 文件，在运行 `tar` 命令压缩文件之前运行
```
chmod 700 mcsmanager/web
chmod 700 mcsmanager/daemon
chmod 700 mcsmanager/
```

---

> 继 #1596 ，本次仅更改 `.github/workflows/release.yml` 文件，希望能一遍过。