### PR TITLE
add macOS support for lib-urls.txt

### DIFF
--- a/lib-urls.txt
+++ b/lib-urls.txt
@@ -1,6 +1,10 @@
 https://github.com/MCSManager/Zip-Tools/releases/download/latest/file_zip_linux_arm64
 https://github.com/MCSManager/Zip-Tools/releases/download/latest/file_zip_linux_x64
 https://github.com/MCSManager/Zip-Tools/releases/download/latest/file_zip_win32_x64.exe
+https://github.com/MCSManager/Zip-Tools/releases/download/latest/file_zip_darwin_arm64
+https://github.com/MCSManager/Zip-Tools/releases/download/latest/file_zip_darwin_amd64
 https://github.com/MCSManager/PTY/releases/download/latest/pty_linux_arm64
 https://github.com/MCSManager/PTY/releases/download/latest/pty_linux_x64
 https://github.com/MCSManager/PTY/releases/download/latest/pty_win32_x64.exe
+https://github.com/MCSManager/PTY/releases/download/latest/pty_darwin_arm64
+https://github.com/MCSManager/PTY/releases/download/latest/pty_darwin_x64


### PR DESCRIPTION
add macOS support for lib-urls.txt from https://github.com/MCSManager/Zip-Tools/releases/ and https:github.com/MCSManager/PTY/releases, so that nodes can be temporarily started based on the Linux version on macOS