### PR TITLE
feat: use xterm.js 5.x instead of 4.x

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,10 @@
         "@uiw/codemirror-theme-dracula": "^4.21.24",
         "@uiw/codemirror-theme-tokyo-night": "^4.23.12",
         "@vueuse/core": "^10.3.0",
+        "@xterm/addon-canvas": "^0.7.0",
+        "@xterm/addon-fit": "^0.10.0",
+        "@xterm/addon-webgl": "^0.18.0",
+        "@xterm/xterm": "^5.5.0",
         "ant-design-vue": "^4.0.7",
         "axios": "^1.8.2",
         "codemirror": "^6.0.1",
@@ -47,8 +51,6 @@
         "vue-i18n": "^9.6.5",
         "vue-router": "^4.2.4",
         "wavesurfer.js": "^7.7.1",
-        "xterm": "^4.12.0",
-        "xterm-addon-fit": "^0.5.0",
         "zrender": "^5.4.4"
       },
       "devDependencies": {
@@ -2664,6 +2666,39 @@
         "@webassemblyjs/ast": "1.12.1",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "node_modules/@xterm/addon-canvas": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-canvas/-/addon-canvas-0.7.0.tgz",
+      "integrity": "sha512-LF5LYcfvefJuJ7QotNRdRSPc9YASAVDeoT5uyXS/nZshZXjYplGXRECBGiznwvhNL2I8bq1Lf5MzRwstsYQ2Iw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
+      "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/addon-webgl": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-webgl/-/addon-webgl-0.18.0.tgz",
+      "integrity": "sha512-xCnfMBTI+/HKPdRnSOHaJDRqEpq2Ugy8LEj9GiY4J3zJObo3joylIFaMvzBwbYRg8zLtkO0KQaStCeSfoaI2/w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
+      "license": "MIT"
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -9706,19 +9741,6 @@
         "node": ">=0.4"
       }
     },
-    "node_modules/xterm": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-4.19.0.tgz",
-      "integrity": "sha512-c3Cp4eOVsYY5Q839dR5IejghRPpxciGmLWWaP9g+ppfMeBChMeLa1DCA+pmX/jyDZ+zxFOmlJL/82qVdayVoGQ=="
-    },
-    "node_modules/xterm-addon-fit": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.5.0.tgz",
-      "integrity": "sha512-DsS9fqhXHacEmsPxBJZvfj2la30Iz9xk+UKjhQgnYNkrUIN5CYLbw7WEfz117c7+S86S/tpHPfvNxJsF5/G8wQ==",
-      "peerDependencies": {
-        "xterm": "^4.0.0"
-      }
-    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -11604,6 +11626,29 @@
         "@webassemblyjs/ast": "1.12.1",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "@xterm/addon-canvas": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-canvas/-/addon-canvas-0.7.0.tgz",
+      "integrity": "sha512-LF5LYcfvefJuJ7QotNRdRSPc9YASAVDeoT5uyXS/nZshZXjYplGXRECBGiznwvhNL2I8bq1Lf5MzRwstsYQ2Iw==",
+      "requires": {}
+    },
+    "@xterm/addon-fit": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
+      "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
+      "requires": {}
+    },
+    "@xterm/addon-webgl": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-webgl/-/addon-webgl-0.18.0.tgz",
+      "integrity": "sha512-xCnfMBTI+/HKPdRnSOHaJDRqEpq2Ugy8LEj9GiY4J3zJObo3joylIFaMvzBwbYRg8zLtkO0KQaStCeSfoaI2/w==",
+      "requires": {}
+    },
+    "@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -16556,17 +16601,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
-    },
-    "xterm": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-4.19.0.tgz",
-      "integrity": "sha512-c3Cp4eOVsYY5Q839dR5IejghRPpxciGmLWWaP9g+ppfMeBChMeLa1DCA+pmX/jyDZ+zxFOmlJL/82qVdayVoGQ=="
-    },
-    "xterm-addon-fit": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.5.0.tgz",
-      "integrity": "sha512-DsS9fqhXHacEmsPxBJZvfj2la30Iz9xk+UKjhQgnYNkrUIN5CYLbw7WEfz117c7+S86S/tpHPfvNxJsF5/G8wQ==",
-      "requires": {}
     },
     "y18n": {
       "version": "5.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,10 @@
     "@uiw/codemirror-theme-dracula": "^4.21.24",
     "@uiw/codemirror-theme-tokyo-night": "^4.23.12",
     "@vueuse/core": "^10.3.0",
+    "@xterm/addon-canvas": "^0.7.0",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-webgl": "^0.18.0",
+    "@xterm/xterm": "^5.5.0",
     "ant-design-vue": "^4.0.7",
     "axios": "^1.8.2",
     "codemirror": "^6.0.1",
@@ -51,8 +55,6 @@
     "vue-i18n": "^9.6.5",
     "vue-router": "^4.2.4",
     "wavesurfer.js": "^7.7.1",
-    "xterm": "^4.12.0",
-    "xterm-addon-fit": "^0.5.0",
     "zrender": "^5.4.4"
   },
   "devDependencies": {

--- a/frontend/src/components/TerminalCore.vue
+++ b/frontend/src/components/TerminalCore.vue
@@ -6,7 +6,7 @@ import { encodeConsoleColor, useTerminal } from "../hooks/useTerminal";
 import { getInstanceOutputLog } from "@/services/apis/instance";
 import { message } from "ant-design-vue";
 import connectErrorImage from "@/assets/daemon_connection_error.png";
-import { Terminal } from "xterm";
+import { Terminal } from "@xterm/xterm";
 import { useCommandHistory } from "@/hooks/useCommandHistory";
 import { useLayoutContainerStore } from "@/stores/useLayoutContainerStore";
 import { getRandomId } from "../tools/randId";

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
           if (path.includes("node_modules/vue") || path.includes("node_modules/@vue")) {
             return "vue";
           }
-          if (path.includes("node_modules/xterm")) {
+          if (path.includes("node_modules/@xterm")) {
             return "xterm";
           }
           if (path.includes("node_modules/@codemirror")) {


### PR DESCRIPTION
Update xterm.js to 5.5.0

Use the WebGL renderer in the terminal when WebGL2 is available

Mapping touch events in the terminal to select text in the terminal on touch screen devices