### PR TITLE
perf: 1000->1024,MBps->Mbps

### DIFF
--- a/daemon/src/service/async_task_service/quick_install.ts
+++ b/daemon/src/service/async_task_service/quick_install.ts
@@ -133,10 +133,10 @@ export class QuickInstallTask extends AsyncTask {
       const now = Date.now();
       const PROGRESS_THROTTLE_MS = 1000;
       if (now - this.lastProgressOutput >= PROGRESS_THROTTLE_MS) {
-        const size = `${prettyBytes(this.downloadProgress.downloadedBytes)}/${prettyBytes(
-          this.downloadProgress.totalBytes
+        const size = `${prettyBytes(this.downloadProgress.downloadedBytes, {binary: true})}/${prettyBytes(
+          this.downloadProgress.totalBytes, {binary: true}
         )}`;
-        const speed = `${prettyBytes(this.downloadProgress.speed)}/s`;
+        const speed = `${prettyBytes(this.downloadProgress.speed*8, {bits: true})}ps`;
         const downloadText = t("TXT_CODE_b135e9bd");
         this.instance.println(
           "INFO",

--- a/daemon/src/service/async_task_service/quick_install.ts
+++ b/daemon/src/service/async_task_service/quick_install.ts
@@ -133,10 +133,10 @@ export class QuickInstallTask extends AsyncTask {
       const now = Date.now();
       const PROGRESS_THROTTLE_MS = 1000;
       if (now - this.lastProgressOutput >= PROGRESS_THROTTLE_MS) {
-        const size = `${prettyBytes(this.downloadProgress.downloadedBytes, {binary: true})}/${prettyBytes(
-          this.downloadProgress.totalBytes, {binary: true}
+        const size = `${prettyBytes(this.downloadProgress.downloadedBytes, { binary: true })}/${prettyBytes(
+          this.downloadProgress.totalBytes, { binary: true }
         )}`;
-        const speed = `${prettyBytes(this.downloadProgress.speed*8, {bits: true})}ps`;
+        const speed = `${prettyBytes(this.downloadProgress.speed * 8, { bits: true })}ps`;
         const downloadText = t("TXT_CODE_b135e9bd");
         this.instance.println(
           "INFO",

--- a/frontend/src/widgets/instance/Terminal.vue
+++ b/frontend/src/widgets/instance/Terminal.vue
@@ -237,7 +237,7 @@ const terminalTopTags = computed<TagInfo[]>(() => {
     },
     {
       label: t("TXT_CODE_50daec4"),
-      value: `↓${prettyBytes(info.rxBytes*8 || 0, {bits: true})}ps ↑${prettyBytes(info.txBytes*8 || 0, {bits: true})}ps`,
+      value: `↓${prettyBytes((info.rxBytes || 0)*8, {bits: true})}ps ↑${prettyBytes((info.txBytes || 0)*8, {bits: true})}ps`,
       condition: () => info.rxBytes != null || info.txBytes != null,
       icon: ArrowUpOutlined
     }

--- a/frontend/src/widgets/instance/Terminal.vue
+++ b/frontend/src/widgets/instance/Terminal.vue
@@ -231,13 +231,13 @@ const terminalTopTags = computed<TagInfo[]>(() => {
     {
       label: t("TXT_CODE_593ee330"),
       value: info.memoryLimit
-        ? `${prettyBytes(info.memoryUsage || 0, {binary: true})}/${prettyBytes(info.memoryLimit, {binary: true})}`
-        : prettyBytes(info.memoryUsage || 0, {binary: true}),
+        ? `${prettyBytes(info.memoryUsage || 0, { binary: true })}/${prettyBytes(info.memoryLimit, { binary: true })}`
+        : prettyBytes(info.memoryUsage || 0, { binary: true }),
       condition: () => info.memoryUsage != null
     },
     {
       label: t("TXT_CODE_50daec4"),
-      value: `↓${prettyBytes((info.rxBytes || 0)*8, {bits: true})}ps ↑${prettyBytes((info.txBytes || 0)*8, {bits: true})}ps`,
+      value: `↓${prettyBytes((info.rxBytes || 0) * 8, { bits: true })}ps ↑${prettyBytes((info.txBytes || 0) * 8, { bits: true })}ps`,
       condition: () => info.rxBytes != null || info.txBytes != null,
       icon: ArrowUpOutlined
     }

--- a/frontend/src/widgets/instance/Terminal.vue
+++ b/frontend/src/widgets/instance/Terminal.vue
@@ -231,13 +231,13 @@ const terminalTopTags = computed<TagInfo[]>(() => {
     {
       label: t("TXT_CODE_593ee330"),
       value: info.memoryLimit
-        ? `${prettyBytes(info.memoryUsage || 0)}/${prettyBytes(info.memoryLimit)}`
-        : prettyBytes(info.memoryUsage || 0),
+        ? `${prettyBytes(info.memoryUsage || 0, {binary: true})}/${prettyBytes(info.memoryLimit, {binary: true})}`
+        : prettyBytes(info.memoryUsage || 0, {binary: true}),
       condition: () => info.memoryUsage != null
     },
     {
       label: t("TXT_CODE_50daec4"),
-      value: `↓${prettyBytes(info.rxBytes || 0)}/s ↑${prettyBytes(info.txBytes || 0)}/s`,
+      value: `↓${prettyBytes(info.rxBytes*8 || 0, {bits: true})}ps ↑${prettyBytes(info.txBytes*8 || 0, {bits: true})}ps`,
       condition: () => info.rxBytes != null || info.txBytes != null,
       icon: ArrowUpOutlined
     }


### PR DESCRIPTION
<img width="427" height="113" alt="image" src="https://github.com/user-attachments/assets/4c60587b-3aa2-4d74-846c-22180008a94d" />

`929 MB/17.2 GB` -> `886 MiB/16 GiB`

`↓0 B/s ↑0 B/s` -> `↓0 bps ↑0 bps`

> This is the definition standardised by the [International Electrotechnical Commission](https://en.wikipedia.org/wiki/International_Electrotechnical_Commission) (IEC).[[2]](https://en.wikipedia.org/wiki/Kilobyte#cite_note-NIST-2) This definition, and the related definitions of the prefixes [mega](https://en.wikipedia.org/wiki/Mega-) (1,000,000), [giga](https://en.wikipedia.org/wiki/Giga-) (1,000,000,000), etc., are most commonly used for [data transfer rates](https://en.wikipedia.org/wiki/Data_rate) in [computer networks](https://en.wikipedia.org/wiki/Computer_network), internal bus, hard drive and flash media transfer speeds, and for the capacities of most [storage media](https://en.wikipedia.org/wiki/Data_storage), particularly [hard disk drives](https://en.wikipedia.org/wiki/Hard_disk_drive),[[3]](https://en.wikipedia.org/wiki/Kilobyte#cite_note-3) [flash](https://en.wikipedia.org/wiki/Flash_memory)-based storage,[[4]](https://en.wikipedia.org/wiki/Kilobyte#cite_note-4) and [DVDs](https://en.wikipedia.org/wiki/DVD). It is also consistent with the other uses of the metric prefixes in computing, such as [CPU clock speeds](https://en.wikipedia.org/wiki/Hertz#Computers) or [measures of performance](https://en.wikipedia.org/wiki/FLOPS).[^1]
> 这是国际电工委员会（IEC）标准化的定义。 [2] 这个定义，以及相关的兆（1,000,000）、吉（1,000,000,000）等前缀的定义，最常用于计算机网络的数据传输速率、内部总线、硬盘和闪存媒体传输速度，以及大多数存储媒体的容量，特别是硬盘、 [3] 基于闪存的存储、 [4] 和 DVD。它也与计算机中公制前缀的其他用法一致，例如 CPU 时钟速度或性能指标。

> In December 1998, the [IEC](https://en.wikipedia.org/wiki/International_Electrotechnical_Commission) addressed such multiple usages and definitions by creating prefixes such as kibi, mebi, gibi, etc., to unambiguously denote powers of 1024.[[10]](https://en.wikipedia.org/wiki/Kilobyte#cite_note-10) Thus the kibibyte, symbol KiB, represents 210 bytes = 1024 bytes. These prefixes are now part of IEC 80000-13. The IEC further specified that the kilobyte should only be used to refer to 1000 bytes. The [International System of Units](https://en.wikipedia.org/wiki/International_System_of_Units) restricts the use of the SI prefixes strictly to powers of 10.[[11]](https://en.wikipedia.org/wiki/Kilobyte#cite_note-11)[^1]
> 1998 年 12 月，IEC 通过创建诸如 kibi、mebi、gibi 等前缀来解决这种多重用途和定义问题，以明确表示 1024 的幂。因此，千字节数（符号 KiB）表示 2^10 字节=1024 字节。这些前缀现已成为 IEC 80000-13 的一部分。IEC 进一步规定，千字节仅应用于指代 1000 字节。国际单位制严格限制 SI 前缀的使用仅限于 10 的幂。
[^1]: https://en.wikipedia.org/wiki/Kilobyte

> Data transfer rates are usually measured in decimal SI multiples.[^2]
> File sizes are often measured in (binary) IEC multiples of bytes, for example 1 KiB = 1024 bytes = 8192 bits. Confusion may arise in cases where (for historic reasons) filesizes are specified with binary multipliers using the ambiguous prefixes K, M, and G rather than the IEC standard prefixes Ki, Mi, and Gi.[[13]](https://en.wikipedia.org/wiki/Bit#cite_note-13)[^2]
> 数据传输速率通常以十进制 SI 倍数来衡量。
> 文件大小通常以（二进制）IEC 字节的倍数来衡量，例如 1 KiB = 1024 字节 = 8192 比特。在（由于历史原因）文件大小使用 K、M 和 G 这些模糊前缀而不是 IEC 标准前缀 Ki、Mi 和 Gi 来指定二进制倍数的情况下，可能会产生混淆。 [13]
[^2]: https://en.wikipedia.org/wiki/Bit