### PR TITLE
fix: `path.join` on win32

### DIFF
--- a/daemon/src/service/system_file.ts
+++ b/daemon/src/service/system_file.ts
@@ -6,6 +6,7 @@ import iconv from "iconv-lite";
 import { globalConfiguration } from "../entity/config";
 import { ProcessWrapper } from "mcsmanager-common";
 import os from "os";
+import { normalizedJoin } from "../tools/filepath";
 
 const ERROR_MSG_01 = $t("TXT_CODE_system_file.illegalAccess");
 const MAX_EDIT_SIZE = 1024 * 1024 * 5;
@@ -21,7 +22,10 @@ interface IFile {
 export default class FileManager {
   public cwd: string = ".";
 
-  constructor(public topPath: string = "", public fileCode?: string) {
+  constructor(
+    public topPath: string = "",
+    public fileCode?: string
+  ) {
     if (!path.isAbsolute(topPath)) {
       this.topPath = path.normalize(path.join(process.cwd(), topPath));
     } else {
@@ -79,7 +83,7 @@ export default class FileManager {
 
   cd(dirName: string) {
     if (!this.check(dirName)) throw new Error(ERROR_MSG_01);
-    this.cwd = path.normalize(path.join(this.cwd, dirName));
+    this.cwd = normalizedJoin(this.cwd, dirName);
   }
 
   list(page: 0, pageSize = 40, searchFileName?: string) {

--- a/daemon/src/tools/filepath.ts
+++ b/daemon/src/tools/filepath.ts
@@ -1,5 +1,7 @@
 import formidable from "formidable";
 import fs from "fs-extra";
+import os from "os";
+import path from "path";
 
 export function checkFileName(fileName: string) {
   const blackKeys = ["/", "\\", "|", "?", "*", ">", "<", ";", '"'];
@@ -18,4 +20,26 @@ export function clearUploadFiles(file?: formidable.File | formidable.File[]) {
   } else {
     fs.remove(file.filepath, () => {});
   }
+}
+
+export function normalizedJoin(...paths: string[]) {
+  if (os.platform() === "win32") {
+    return joinWin32(...paths);
+  }
+  return path.normalize(path.join(...paths));
+}
+
+function joinWin32(...paths: string[]): string {
+  if (!paths.length) return ".";
+  if (paths.length == 1) return paths[0];
+  const parts = path.win32.parse(paths[1]);
+  let p: string;
+  if (parts.root) {
+    p = paths[1];
+  } else {
+    p = path.normalize(path.join(paths[0], paths[1]));
+  }
+  if (paths.length <= 2) return p;
+
+  return joinWin32(p, ...paths.slice(2));
 }


### PR DESCRIPTION
- fix #1718 