### PR TITLE
refactor: clear `CMD` when `ENTRYPOINT` is not empty

### DIFF
--- a/daemon/src/service/docker_process_service.ts
+++ b/daemon/src/service/docker_process_service.ts
@@ -226,7 +226,7 @@ export class SetupDockerContainer extends AsyncTask {
       Tty: isTty,
       WorkingDir: dockerConfig.changeWorkdir ? workingDir : undefined,
       Entrypoint: commandList.length ? commandList[0] : void 0,
-      Cmd: commandList.length > 1 ? commandList.slice(1) : undefined,
+      Cmd: commandList.length ? commandList.slice(1) : undefined,
       OpenStdin: true,
       StdinOnce: false,
       ExposedPorts: exposedPorts,


### PR DESCRIPTION
I think it is better to clear `CMD` when `ENTRYPOINT` is overwritten.
Otherwise, the default `CMD` in the docker image may affect the new executable with no arguments.