### PR TITLE
fix: sort-instances-before-pagination

### DIFF
--- a/daemon/src/routers/Instance_router.ts
+++ b/daemon/src/routers/Instance_router.ts
@@ -69,9 +69,7 @@ routerApp.on("instance/select", (ctx, data) => {
     }
     return true;
   });
-  result = result.sort((a, b) => (a.config.nickname > b.config.nickname ? 1 : -1));
-
-  // sort first by status, then by name
+  // sort first by status， then by nickname
   result.sort((a, b) => {
     if (a.status() !== b.status()) {
       return b.status() - a.status();


### PR DESCRIPTION
This pull request refactors the `Instance_router.ts` file to improve import organization and modifies the sorting logic for instance selection. The most significant change is the adjustment of sorting behavior for instances, ensuring that they are now sorted first by status and then by nickname.

### Code organization and import cleanup
* Refactored and reordered imports in `Instance_router.ts` for better clarity and maintainability, grouping related modules and removing duplicate or unused imports.

### Instance selection and sorting improvements
* Updated the sorting logic in the `instance/select` event handler to sort instances first by their status (descending), then by nickname (alphabetically), improving the user experience when viewing instance lists.
* Removed redundant sorting of the `overview` array by status and nickname, as the sorting is now handled earlier in the selection logic.
* Fix issue https://github.com/MCSManager/MCSManager/issues/1789