### PR TITLE
fix: Update docker.yml to use EMBEDDED_JAVA_VERSION

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -99,4 +99,4 @@ jobs:
           labels: ${{ steps.meta_daemon.outputs.labels }}
           build-args: |
             BUILDPLATFORM=linux/amd64
-            JAVA_RUNTIME=${{ matrix.java_version }}
+            EMBEDDED_JAVA_VERSION=${{ matrix.java_version }}


### PR DESCRIPTION
Current GitHub Actions always builds the MCSM Daemon with JDK 21 because of misspelled variable name. This PR fixes that.