### PR TITLE
feat(web): optimize terminal Ctrl+C interaction logic

### DIFF
--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -271,11 +271,17 @@ export function useTerminal() {
       if (arg.type === "keydown" && arg.ctrlKey && arg.code === "KeyC") {
         const selection = term.getSelection();
         if (selection) {
-          navigator.clipboard.writeText(selection).then(() => {
+          // If not in SecureContext, writeText will fail. Fallback to browser's default copy behavior, but selection won't be cleared.
+          if (window.isSecureContext) {
+            arg.preventDefault()
+          }
+
+          navigator.clipboard?.writeText(selection).then(() => {
              term.clearSelection();
           }).catch(err => {
              console.error("Could not copy text: ", err);
           });
+
           return false;
         }
       }


### PR DESCRIPTION
优化终端的 Ctrl+C 交互逻辑，使其符合主流终端操作习惯（如 Windows Terminal, VSCode）。

### 改动逻辑：
1. 当有选区时：按下 Ctrl+C 执行复制操作，清除选区（在安全上下文中），不发送信号。
2. 当无选区时：保持原有逻辑（触发双击确认提示）。

这解决了 #1274 中提到的复制操作容易误关服的问题，同时保留了防误触机制。

### 代码改动：
frontend/src/hooks/useTerminal.ts: 增加 attachCustomKeyEventHandler 处理复制逻辑。
