### PR TITLE
fix: properly display Docker environment and label configurations

### DIFF
--- a/frontend/src/widgets/instance/dialogs/InstanceDetail.vue
+++ b/frontend/src/widgets/instance/dialogs/InstanceDetail.vue
@@ -389,8 +389,8 @@ const handleEditDockerConfig = async (type: "port" | "volume" | "env" | "label")
     const envs = formData.value.instance.config.docker.env?.map((v) => {
       const tmp = v.split("=");
       return {
-        label: tmp[0] || "",
-        value: tmp[1] || ""
+        label: tmp.shift() || "",
+        value: tmp.join("=") || ""
       };
     });
     const result = await useDockerEnvEditDialog(envs);
@@ -402,8 +402,8 @@ const handleEditDockerConfig = async (type: "port" | "volume" | "env" | "label")
     const labels = formData.value.instance.config.docker.labels?.map((v) => {
       const tmp = v.split("=");
       return {
-        label: tmp[0] || "",
-        value: tmp[1] || ""
+        label: tmp.shift() || "",
+        value: tmp.join("=") || ""
       };
     });
     const result = await useDockerLabelEditDialog(labels);


### PR DESCRIPTION
Fixes a UI issue where Docker environment variables and labels were displayed incorrectly when their values contained `=`.

For example, setting:
> MAPPING=server1=server1:25565,server2=server2:25565

would only show `server1` in the UI after saving, even though the full value was correctly passed to the container.

This is a simple quick fix for the common case. Using `=` in the key is still an edge case and not handled here.