### PR TITLE
Fix: Prevent path traversal in FileManager #security

### DIFF
--- a/daemon/src/service/system_file.ts
+++ b/daemon/src/service/system_file.ts
@@ -70,7 +70,18 @@ export default class FileManager {
     if (this.isRootTopRath()) return true;
     const destAbsolutePath = this.toAbsolutePath(fileNameOrPath);
     const topAbsolutePath = this.topPath;
-    return destAbsolutePath.indexOf(topAbsolutePath) === 0;
+
+    // Fix: Path Traversal Vulnerability
+    if (destAbsolutePath.startsWith(topAbsolutePath)) {
+      // Ensure it's not a sibling folder with the same prefix
+      // e.g. /data vs /data_secret
+      if (destAbsolutePath.length > topAbsolutePath.length) {
+        const barrierChar = destAbsolutePath.charAt(topAbsolutePath.length);
+        if (barrierChar !== path.sep) return false;
+      }
+      return true;
+    }
+    return false;
   }
 
   check(destPath: string) {
@@ -240,7 +251,7 @@ export default class FileManager {
         filesPath.push(this.toAbsolutePath(iterator));
         try {
           totalSize += fs.statSync(this.toAbsolutePath(iterator))?.size;
-        } catch (error: any) {}
+        } catch (error: any) { }
       }
     }
     if (totalSize > MAX_TOTAL_FIELS_SIZE)


### PR DESCRIPTION
## Summary
Fixed a high-severity path traversal vulnerability in `FileManager.checkPath`. The original implementation used a weak prefix check (`indexOf() === 0`) which allowed access to sibling directories sharing the same prefix (e.g., `/app/data_secret` when top path is `/app/data`).

## Changes
- Replaced `indexOf` check with strict `startsWith` validation.
- Added logic to ensure the path is either an exact match or followed by a path separator.

## Testing
- Verified with a standalone logic script which confirmed that sibling paths are now correctly rejected while valid child paths are accepted.