### PR TITLE
docs: Update Docker configuration for rootless mode in README and doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,18 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 ```
 
+Note (Rootless Docker on Linux): the daemon supports `DOCKER_HOST`. If your Docker daemon runs in rootless mode, the socket is usually at `/run/user/<uid>/docker.sock` instead of `/var/run/docker.sock`. In that case, replace the default socket mount with the rootless socket and set `DOCKER_HOST`, for example:
+
+```yml
+  daemon:
+    environment:
+      - DOCKER_HOST=unix:///run/user/1000/docker.sock
+    volumes:
+      - /run/user/1000/docker.sock:/run/user/1000/docker.sock
+```
+
+Replace `1000` with your actual UID (`id -u`).
+
 Enable using docker-compose.
 
 ```bash

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -212,6 +212,18 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 ```
 
+注意（Linux Rootless Docker）：Daemon 端已支持读取 `DOCKER_HOST`。如果你的 Docker 运行在 rootless 模式，socket 通常位于 `/run/user/<uid>/docker.sock`（而不是 `/var/run/docker.sock`）。此时请把默认的 socket 挂载替换为 rootless socket，并设置 `DOCKER_HOST`，例如：
+
+```yml
+  daemon:
+    environment:
+      - DOCKER_HOST=unix:///run/user/1000/docker.sock
+    volumes:
+      - /run/user/1000/docker.sock:/run/user/1000/docker.sock
+```
+
+把 `1000` 替换成你的实际 UID（`id -u`）。
+
 使用 docker-compose 启用。
 
 ```bash

--- a/example.docker-compose.yml
+++ b/example.docker-compose.yml
@@ -17,9 +17,14 @@ services:
     #   - "24444:24444"
     environment:
       - MCSM_DOCKER_WORKSPACE_PATH=<CHANGE_ME_TO_INSTALL_PATH>/daemon/data/InstanceData
+      # Rootless Docker (Linux): set DOCKER_HOST to your user socket path
+      # - DOCKER_HOST=unix:///run/user/1000/docker.sock
     volumes:
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
       - <CHANGE_ME_TO_INSTALL_PATH>/daemon/data:/opt/mcsmanager/daemon/data
       - <CHANGE_ME_TO_INSTALL_PATH>/daemon/logs:/opt/mcsmanager/daemon/logs
+      # Rootful Docker (default):
       - /var/run/docker.sock:/var/run/docker.sock
+      # Rootless Docker (Linux): replace the line above with:
+      # - /run/user/1000/docker.sock:/run/user/1000/docker.sock


### PR DESCRIPTION
fork仓库内进行了分支迁移，重新发起合并请求

docs: 补充 Rootless Docker 的 DOCKER_HOST 与 socket 挂载说明

Relates to https://github.com/MCSManager/MCSManager/issues/1912

背景 / 问题
在 Linux Rootless Docker 场景下，Docker daemon 的 socket 通常位于 /run/user/<uid>/docker.sock。
此前文档与示例 compose 默认固定挂载 /var/run/docker.sock，容易让用户误以为已配置 DOCKER_HOST 仍然无效，导致连接报错（ENOENT 等）。

变更内容
更新 README.md：补充 Rootless Docker 配置说明与示例（挂载 rootless socket + 设置 DOCKER_HOST）
更新 README_ZH.md：同步补充 Rootless Docker 配置说明与示例
更新 example.docker-compose.yml：增加注释指引（rootful 默认 / rootless 替换方案）
使用示例（Rootless Docker）
获取 UID：id -u
在 daemon 容器环境中设置：
DOCKER_HOST=unix:///run/user/<uid>/docker.sock
将默认的 /var/run/docker.sock:/var/run/docker.sock 替换为：
/run/user/<uid>/docker.sock:/run/user/<uid>/docker.sock