### PR TITLE
fix: Java Manager only care startCommand first position 

### DIFF
--- a/daemon/src/entity/instance/instance.ts
+++ b/daemon/src/entity/instance/instance.ts
@@ -247,7 +247,7 @@ export default class Instance extends EventEmitter {
       configureEntityParams(this.config.terminalOption, cfg.terminalOption, "haveColor", Boolean);
     }
 
-    if (cfg.startCommand && commandStringToArray(cfg.startCommand)[0] != "{mcsm_java}") {
+    if (cfg.startCommand && !commandStringToArray(cfg.startCommand).includes("{mcsm_java}")) {
       this.config.java.id = "";
     } else if (cfg.java) {
       configureEntityParams(this.config.java, cfg.java, "id", String);


### PR DESCRIPTION
> some times, we may start a Minecraft Forge Server with `./run.sh`
> but this method doesn't support our Java Manager
> so I modified the run.sh, make arg "$1" as the java path
> so my startCommand is `./run.sh {mcsm_java}`
> but I find it's imposible to make it without modify config file manually...

this is origin code
```TypeScript
if (cfg.startCommand && commandStringToArray(cfg.startCommand)[0] != "{mcsm_java}") {
  this.config.java.id = "";
} else if (cfg.java) {
  configureEntityParams(this.config.java, cfg.java, "id", String);
}
```
it will uncheck java id if `commandStringToArray(cfg.startCommand)[0]` not `{mcsm_java}`
so I make it `.includes("{mcsm_java}")`
ok.

### **But**
there may have similar problem with `java_manager_router.ts`
```TypeScript
routerApp.on("java_manager/using", async (ctx, data) => {
  try {
    const instance = instanceManager.getInstance(data.instanceId);
    if (!instance) throw new Error($t("TXT_CODE_ef6b54fb"));

    const startCommandList = commandStringToArray(instance.config.startCommand);
    startCommandList[0] = "{mcsm_java}";
    instance.parameters({
      java: {
        id: data.id
      },
      startCommand: startCommandList.join(" ")
    });

    protocol.response(ctx, true);
  } catch (error: any) {
    protocol.responseError(ctx, error);
  }
});
```
and I have no choice on how to solve it...
maybe like this?
- ```TypeScript
  const javaKeywords = ["java", "java.exe", "java.bat", "java.sh"];
  if(javaKeywords.includes(startCommandList[0])) startCommandList[0] = "{mcsm_java}";
  ```
- ```TypeScript
  const javaKeywords = ["java", "java.exe", "java.bat", "java.sh"];
  const javaIndex = startCommandList.findIndex(cmd => javaKeywords.includes(cmd));
  if (javaIndex !== -1) startCommandList[javaIndex] = "{mcsm_java}";
  ```
  
but it cant cover more complex situations......
like `./run.sh /usr/bin/java`
maybe keep `java_manager_router.ts` unchanged is best choice?