### PR TITLE
Support LoongArch

### DIFF
--- a/daemon/src/service/docker_service.ts
+++ b/daemon/src/service/docker_service.ts
@@ -152,6 +152,8 @@ export class DockerManager {
         armv7l: "arm",
         armv6l: "arm",
         arm: "arm",
+        loong64: "loong64",
+        loongarch64: "loong64",
         ppc64le: "ppc64le",
         s390x: "s390x",
         i386: "386",
@@ -170,7 +172,8 @@ export class DockerManager {
       const archMap: Record<string, string> = {
         x64: "amd64",
         arm64: "arm64",
-        arm: "arm"
+        arm: "arm",
+        loong64: "loong64"
       };
       const platformArch = archMap[nodeArch] || nodeArch;
       return [`${osType}/${platformArch}`];

--- a/lib-urls.txt
+++ b/lib-urls.txt
@@ -1,4 +1,5 @@
 https://github.com/MCSManager/Zip-Tools/releases/latest/download/file_zip_linux_arm64
+https://github.com/MCSManager/Zip-Tools/releases/latest/download/file_zip_linux_loong64
 https://github.com/MCSManager/Zip-Tools/releases/latest/download/file_zip_linux_x64
 https://github.com/MCSManager/Zip-Tools/releases/latest/download/file_zip_win32_x64.exe
 https://github.com/MCSManager/Zip-Tools/releases/latest/download/file_zip_darwin_arm64
@@ -12,6 +13,7 @@ https://github.com/MCSManager/Zip-Tools/releases/latest/download/7z_darwin_x64
 https://github.com/MCSManager/Zip-Tools/releases/latest/download/7z-extra-license.txt
 https://github.com/MCSManager/Zip-Tools/releases/latest/download/7z-unix-license.txt
 https://github.com/MCSManager/PTY/releases/download/latest/pty_linux_arm64
+https://github.com/MCSManager/PTY/releases/download/latest/pty_linux_loong64
 https://github.com/MCSManager/PTY/releases/download/latest/pty_linux_x64
 https://github.com/MCSManager/PTY/releases/download/latest/pty_win32_x64.exe
 https://github.com/MCSManager/PTY/releases/download/latest/pty_darwin_arm64


### PR DESCRIPTION
# Brief
Add basic LoongArch support to MCSManager.
The basic functions have been tested on actual machines.
* It can start the Minecraft server normally, and can create a contianer using the local Docker image.
* The required binary tools (PTY, file_zip) can also be compiled and run on LoongArch.
* Although the mainline version of Node.js supports LoongArch, no dist tarball is provided by the "[nodejs](https://nodejs.org/dist/)" site directly. It has to be downloaded from the "[unofficial-build](https://unofficial-builds.nodejs.org/)" site in the setup script.

These PRs are also required:
https://github.com/MCSManager/Script/pull/103
https://github.com/MCSManager/PTY/pull/21
https://github.com/MCSManager/Zip-Tools/pull/3
# Screenshot
<img width="2151" height="1857" alt="QQ20260314-195907" src="https://github.com/user-attachments/assets/a088d6d6-05c9-4926-93fa-499cc90ec02d" />

<img width="2127" height="1863" alt="QQ20260314-201019" src="https://github.com/user-attachments/assets/2b8b5fc0-e095-459c-9d7a-1b976531880e" />
