### PR TITLE
Feat/docker network

### DIFF
--- a/daemon/src/entity/commands/task/docker_stats.ts
+++ b/daemon/src/entity/commands/task/docker_stats.ts
@@ -1,12 +1,10 @@
 import Dockerode from "dockerode";
-import { NetworkLimitService } from "../../../service/network_limit_service";
 import { DefaultDocker } from "../../../service/docker_service";
 import Instance from "../../instance/instance";
 import { ILifeCycleTask } from "../../instance/life_cycle";
 
 export default class DockerStatsTask implements ILifeCycleTask {
   private static defaultDocker = new DefaultDocker();
-  private static networkLimitService = NetworkLimitService.getInstance();
 
   public status: number = 0;
   public name: string = "DockerStats";
@@ -127,28 +125,14 @@ export default class DockerStatsTask implements ILifeCycleTask {
       let rxRate: number | undefined = undefined;
       let txRate: number | undefined = undefined;
       let networkInterfaces: string[] | undefined = undefined;
-      let networkStatsSource: "namespace" | "docker" | undefined = undefined;
+      let networkStatsSource: "docker" | undefined = undefined;
 
       try {
-        let networkStats = null;
-        const linuxNetworkStatsSupported =
-          await DockerStatsTask.networkLimitService.isLinuxEnvironmentSupported();
-        if (linuxNetworkStatsSupported) {
-          networkStats = await DockerStatsTask.networkLimitService.getContainerNetworkStats(
-            containerId
-          );
-        }
-        rxBytes = networkStats?.rxBytes;
-        txBytes = networkStats?.txBytes;
-        networkInterfaces = networkStats?.interfaceNames;
-        networkStatsSource = networkStats?.source;
-        if (rxBytes == null || txBytes == null) {
-          const fallbackStats = this.getDockerNetworkCumulative(stats.networks);
-          rxBytes = fallbackStats.rxBytes;
-          txBytes = fallbackStats.txBytes;
-          networkInterfaces = fallbackStats.interfaceNames;
-          networkStatsSource = fallbackStats.source;
-        }
+        const networkStats = this.getDockerNetworkCumulative(stats.networks);
+        rxBytes = networkStats.rxBytes;
+        txBytes = networkStats.txBytes;
+        networkInterfaces = networkStats.interfaceNames;
+        networkStatsSource = networkStats.source;
 
         const networkRates = this.calculateRealTimeRate({ rxBytes, txBytes }, "network");
         rxRate = networkRates.rxBytes;

--- a/daemon/src/entity/instance/instance.ts
+++ b/daemon/src/entity/instance/instance.ts
@@ -36,7 +36,7 @@ interface IInstanceInfo {
   rxRate?: number;
   txRate?: number;
   networkInterfaces?: string[];
-  networkStatsSource?: "namespace" | "docker";
+  networkStatsSource?: "docker";
   readBytes?: number;
   writeBytes?: number;
   memoryUsage?: number;

--- a/daemon/src/service/network_limit_service.ts
+++ b/daemon/src/service/network_limit_service.ts
@@ -11,13 +11,6 @@ export interface BandwidthLimit {
   downloadLimit?: number;
 }
 
-export interface ContainerNetworkStats {
-  rxBytes?: number;
-  txBytes?: number;
-  interfaceNames?: string[];
-  source?: "namespace" | "docker";
-}
-
 interface LinuxBandwidthState {
   pid: number;
   interfaceName: string;
@@ -26,16 +19,12 @@ interface LinuxBandwidthState {
 }
 
 export class NetworkLimitService {
-  private static readonly STATS_WARNED_CONTAINERS_LIMIT = 512;
   private static instance: NetworkLimitService;
   private docker: Dockerode;
-  private activeLimits: Map<string, BandwidthLimit> = new Map();
   private activeStates: Map<string, LinuxBandwidthState> = new Map();
   private linuxEnvironmentReady = false;
   private linuxEnvironmentUnsupportedReason?: string;
   private linuxEnvironmentWarningEmitted = false;
-  private statsWarnedContainers = new Set<string>();
-  private statsWarnedOrder: string[] = [];
 
   private constructor() {
     this.docker = new DefaultDocker();
@@ -87,7 +76,6 @@ export class NetworkLimitService {
         await this.verifyUploadLimit(pid, interfaceName);
       }
 
-      this.activeLimits.set(containerId, normalizedLimit);
       this.activeStates.set(containerId, state);
       logger.info(
         `[NetworkLimitService] Applied Linux tc limits for ${containerId} on ${interfaceName} ` +
@@ -115,8 +103,6 @@ export class NetworkLimitService {
   public async clearBandwidthLimit(containerId: string): Promise<void> {
     const state = this.activeStates.get(containerId);
     if (!state) {
-      this.activeLimits.delete(containerId);
-      this.clearStatsWarning(containerId);
       return;
     }
 
@@ -130,69 +116,6 @@ export class NetworkLimitService {
 
     await Promise.all(cleanupTasks.map((task) => task.catch(() => undefined)));
     this.activeStates.delete(containerId);
-    this.activeLimits.delete(containerId);
-    this.clearStatsWarning(containerId);
-  }
-
-  public getBandwidthLimit(containerId: string): BandwidthLimit | undefined {
-    return this.activeLimits.get(containerId);
-  }
-
-  public async getContainerNetworkStats(containerId: string): Promise<ContainerNetworkStats | null> {
-    const linuxSupported = await this.isLinuxEnvironmentSupported();
-    if (!linuxSupported) {
-      return null;
-    }
-
-    let pid: number | undefined;
-    let interfaceNames: string[] = [];
-
-    try {
-      const state = this.activeStates.get(containerId);
-      pid = state?.pid;
-
-      if (!pid) {
-        const inspect = await this.inspectContainer(containerId);
-        const networkMode = this.getNetworkMode(inspect);
-        if (networkMode === "none") return null;
-        this.ensureSupportedNetworkMode(networkMode);
-        pid = this.ensureContainerPid(inspect.State?.Pid);
-      }
-
-      interfaceNames = await this.resolveContainerInterfaceNames(pid);
-      if (!interfaceNames.length) {
-        throw new Error(`Unable to resolve container network interfaces for PID ${pid}`);
-      }
-
-      if (this.looksLikeHostNamespaceInterfaces(interfaceNames)) {
-        throw new Error(
-          `Detected host-like interfaces in namespace stats: ${interfaceNames.join(",")}`
-        );
-      }
-
-      let rxBytes = 0;
-      let txBytes = 0;
-      for (const interfaceName of interfaceNames) {
-        rxBytes += await this.readInterfaceCounter(pid, interfaceName, "rx_bytes");
-        txBytes += await this.readInterfaceCounter(pid, interfaceName, "tx_bytes");
-      }
-
-      return {
-        rxBytes,
-        txBytes,
-        interfaceNames,
-        source: "namespace"
-      };
-    } catch (error) {
-      if (this.markStatsWarning(containerId)) {
-        logger.warn(
-          `[NetworkLimitService] Failed to read container network counters for ${containerId} ` +
-            `(pid=${pid ?? "unknown"}, interfaces=${interfaceNames.join(",") || "unknown"}), fallback to Docker API stats. ` +
-            `Error: ${this.getErrorMessage(error)}`
-        );
-      }
-      return null;
-    }
   }
 
   private normalizeLimit(value?: number): number | undefined {
@@ -227,41 +150,6 @@ export class NetworkLimitService {
       }
       throw new Error(this.linuxEnvironmentUnsupportedReason);
     }
-  }
-
-  public async isLinuxEnvironmentSupported(): Promise<boolean> {
-    try {
-      await this.ensureLinuxEnvironment();
-      return true;
-    } catch (error) {
-      return false;
-    }
-  }
-
-  public clearStatsWarning(containerId: string): void {
-    if (!this.statsWarnedContainers.has(containerId)) {
-      return;
-    }
-    this.statsWarnedContainers.delete(containerId);
-    this.statsWarnedOrder = this.statsWarnedOrder.filter((id) => id !== containerId);
-  }
-
-  private markStatsWarning(containerId: string): boolean {
-    if (this.statsWarnedContainers.has(containerId)) {
-      return false;
-    }
-
-    this.statsWarnedContainers.add(containerId);
-    this.statsWarnedOrder.push(containerId);
-
-    if (this.statsWarnedOrder.length > NetworkLimitService.STATS_WARNED_CONTAINERS_LIMIT) {
-      const oldestContainerId = this.statsWarnedOrder.shift();
-      if (oldestContainerId) {
-        this.statsWarnedContainers.delete(oldestContainerId);
-      }
-    }
-
-    return true;
   }
 
   private async inspectContainer(containerId: string) {
@@ -372,14 +260,6 @@ done`
     return /^[a-zA-Z0-9_.:-]+$/.test(interfaceName);
   }
 
-  private looksLikeHostNamespaceInterfaces(interfaceNames: string[]): boolean {
-    if (!interfaceNames.length) return false;
-    return interfaceNames.some((name) => {
-      if (name === "docker0") return true;
-      return /^(br-|veth|virbr|cni|flannel|kube-|cali|zt|tailscale)/.test(name);
-    });
-  }
-
   private ensureValidInterfaceName(interfaceName: string): string {
     if (!this.isValidInterfaceName(interfaceName)) {
       throw new Error(`Invalid interface name: ${interfaceName}`);
@@ -439,27 +319,6 @@ done`
       pid,
       `tc qdisc replace dev ${safeInterface} root tbf rate ${rateBitPerSecond}bit burst 32kbit latency 400ms`
     );
-  }
-
-  private async readInterfaceCounter(
-    pid: number,
-    interfaceName: string,
-    counterName: "rx_bytes" | "tx_bytes"
-  ): Promise<number> {
-    const safeInterface = this.ensureValidInterfaceName(interfaceName);
-    await this.execInNetworkNamespace(
-      pid,
-      `[ -r /sys/class/net/${safeInterface}/statistics/${counterName} ]`
-    );
-    const result = await this.execInNetworkNamespace(
-      pid,
-      `cat /sys/class/net/${safeInterface}/statistics/${counterName}`
-    );
-    const value = Number(result.stdout.trim());
-    if (!Number.isFinite(value) || value < 0) {
-      throw new Error(`Invalid ${counterName} value for ${safeInterface}: ${result.stdout.trim()}`);
-    }
-    return value;
   }
 
   private async deleteQdisc(pid: number, interfaceName: string, parent: "root" | "ingress") {

--- a/frontend/src/components/TerminalTopTags.vue
+++ b/frontend/src/components/TerminalTopTags.vue
@@ -20,7 +20,7 @@ interface TerminalRuntimeInfo {
   rxRate?: number;
   txRate?: number;
   networkInterfaces?: string[];
-  networkStatsSource?: "namespace" | "docker";
+  networkStatsSource?: "docker";
   storageUsage?: number;
   storageLimit?: number;
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -36,7 +36,7 @@ export interface InstanceRuntimeInfo {
   rxRate?: number;
   txRate?: number;
   networkInterfaces?: string[];
-  networkStatsSource?: "namespace" | "docker";
+  networkStatsSource?: "docker";
   readBytes?: number;
   writeBytes?: number;
   memoryUsage?: number;


### PR DESCRIPTION
# Docker 网络限速逻辑精简 - PR 变更说明

## 背景

当前 Docker 网络限速实现同时包含两部分职责：

1. **网络限速**：在 Linux 下通过 `tc` + `nsenter` 对容器网络接口施加上传/下载限速。
2. **网络监控**：在 `NetworkLimitService` 中通过容器 network namespace 读取 `/sys/class/net/*/statistics`，并在 `docker_stats` 中与 Docker API 的 `stats.networks` 统计混合使用。

这导致 `NetworkLimitService` 同时承担“限速服务”和“监控服务”两类职责，存在以下问题：

- 逻辑职责不单一，服务边界不清晰。
- 网络统计存在 **namespace** 与 **docker** 双数据源切换，容易造成速率抖动和行为复杂化。
- namespace 统计依赖额外命令、权限和启发式判定逻辑，维护成本较高。
- 对于“基础 Docker 网络限速”需求而言，监控逻辑并非必要。

因此，本次改造目标是：

> **只保留最基础的 Docker 网络限速能力，彻底删除 `NetworkLimitService` 中的监控相关机制。**

---

## 本次改造目标

- 保留 Docker 容器启动后的上传/下载限速设置能力。
- 保留容器停止后的限速清理能力。
- 删除 `NetworkLimitService` 内部所有网络监控、fallback、告警去重、namespace 统计相关实现。
- 统一由已有的 Docker stats 机制承担网络流量统计职责。
- 尽量保持现有对外接口兼容，降低前端和上层调用影响。

---

## 主要变更

### 1. 精简 `NetworkLimitService`

文件： [daemon/src/service/network_limit_service.ts](../daemon/src/service/network_limit_service.ts)

#### 保留的能力

- `setBandwidthLimit()`
- `clearBandwidthLimit()`
- Linux 环境检测
- 容器 PID 解析
- 容器网络接口解析
- `tc` 规则应用与校验
- 异常时 qdisc 回滚

#### 删除的能力

- `ContainerNetworkStats`
- `getContainerNetworkStats()`
- `isLinuxEnvironmentSupported()`
- `getBandwidthLimit()`
- `readInterfaceCounter()`
- `looksLikeHostNamespaceInterfaces()`
- stats 告警去重相关状态与方法：
  - `STATS_WARNED_CONTAINERS_LIMIT`
  - `statsWarnedContainers`
  - `statsWarnedOrder`
  - `markStatsWarning()`
  - `clearStatsWarning()`
- 用于缓存限速值但未被实际使用的 `activeLimits`

#### 改造后的职责

`NetworkLimitService` 现在只负责：

- **设置限速**
- **清理限速**
- **处理与 tc 规则相关的 Linux 实现细节**

不再负责任何网络统计或监控相关逻辑。

---

### 2. `docker_stats` 统一改为仅使用 Docker API 统计

文件： [daemon/src/entity/commands/task/docker_stats.ts](../daemon/src/entity/commands/task/docker_stats.ts)

#### 改造前

`DockerStatsTask` 会优先尝试：

1. 调用 `NetworkLimitService.isLinuxEnvironmentSupported()`
2. 调用 `NetworkLimitService.getContainerNetworkStats()` 获取 namespace 统计
3. 若失败，再 fallback 到 `stats.networks`

#### 改造后

直接统一使用：

- `container.stats({ stream: false })`
- `stats.networks`
- `getDockerNetworkCumulative()`
- `calculateRealTimeRate()`

#### 效果

- 移除对 `NetworkLimitService` 的监控依赖。
- 不再存在 namespace / docker 双源切换。
- 网络流量与速率计算路径更加稳定、直接、可预测。

---

### 3. 收敛 `networkStatsSource` 类型定义

本次改造后，运行时网络统计源仅保留 `docker`。

已同步修改以下类型：

- [daemon/src/entity/instance/instance.ts](../daemon/src/entity/instance/instance.ts)
- [frontend/src/types/index.ts](../frontend/src/types/index.ts)
- [frontend/src/components/TerminalTopTags.vue](../frontend/src/components/TerminalTopTags.vue)

#### 改造前

```ts
networkStatsSource?: "namespace" | "docker";
```

#### 改造后

```ts
networkStatsSource?: "docker";
```

这样可以明确表达：

- 当前系统仍支持网络统计；
- 但统计来源固定为 Docker API；
- 不再保留 namespace 统计语义。

---

## 保留的原有机制

本次改造 **没有** 改动限速参数传递链路，仍然沿用已有机制。

### 配置传递链

1. Docker 配置中设置：
   - `uploadSpeedLimit`
   - `downloadSpeedLimit`
2. 通过 `instance.parameters()` 写入实例配置。
3. 容器启动后，在 `SetupDockerContainer.onStart()` 中调用：
   - `NetworkLimitService.getInstance().setBandwidthLimit(...)`
4. 容器停止后，在 `onStop()` 中调用：
   - `clearBandwidthLimit(...)`

关键文件：

- [daemon/src/entity/instance/Instance_config.ts](../daemon/src/entity/instance/Instance_config.ts)
- [daemon/src/entity/instance/instance.ts](../daemon/src/entity/instance/instance.ts)
- [daemon/src/service/docker_process_service.ts](../daemon/src/service/docker_process_service.ts)

这意味着：

- 前端配置入口无需调整；
- 实例配置结构无需重做；
- 生命周期中的限速应用/清理流程保持不变。

---

## 影响范围

### 后端

#### 受影响文件

- [daemon/src/service/network_limit_service.ts](../daemon/src/service/network_limit_service.ts)
- [daemon/src/entity/commands/task/docker_stats.ts](../daemon/src/entity/commands/task/docker_stats.ts)
- [daemon/src/entity/instance/instance.ts](../daemon/src/entity/instance/instance.ts)

#### 行为变化

- `NetworkLimitService` 不再提供网络统计能力。
- Docker 网络统计统一来自 Docker API。
- `networkStatsSource` 不再出现 `namespace`。

### 前端

#### 受影响文件

- [frontend/src/types/index.ts](../frontend/src/types/index.ts)
- [frontend/src/components/TerminalTopTags.vue](../frontend/src/components/TerminalTopTags.vue)

#### 行为变化

- 前端展示的网络流量与带宽仍然存在。
- 数据源固定为 Docker stats。
- 类型上不再接受 `namespace`。

---

## 删除监控逻辑后的收益

### 1. 服务职责更清晰

`NetworkLimitService` 从“限速 + 监控”变为纯“限速服务”。

### 2. 维护成本更低

去掉了：

- namespace 统计
- 额外命令依赖的监控逻辑
- host-like interface 启发式判断
- stats fallback 告警去重

### 3. 行为更稳定

网络流量统计只保留 Docker 一个来源，避免双源切换导致的数据不一致与速率抖动。

### 4. 改动风险较小

限速配置入口、生命周期调用链、前端展示结构均保留，属于“内部机制简化”。

---

## 验证结果

### 已完成验证

#### Daemon 构建

在 [daemon/package.json](../daemon/package.json) 对应目录执行：

- `npm run build`

结果：**通过**

#### Frontend 类型检查

在 [frontend/package.json](../frontend/package.json) 对应目录执行：

- `npm run type-check`

结果：**通过**

### 结论

本次改造后：

- Docker 限速功能仍然保留；
- 网络统计仍然可用；
- 监控来源统一为 Docker；
- 删除了 `NetworkLimitService` 中的多余监控机制；
- 当前改动无编译错误、无类型错误。

---

## PR 摘要（可直接用于 PR Description）

### What

This PR simplifies Docker network limiting by removing monitoring/statistics logic from `NetworkLimitService` and keeping it focused on bandwidth limiting only.

### Why

The previous implementation mixed two responsibilities:

- applying Linux `tc` bandwidth limits
- collecting network statistics from container namespaces

That made the service harder to maintain and introduced dual network stats sources (`namespace` and `docker`).

### Changes

- Removed namespace-based monitoring/statistics logic from `NetworkLimitService`
- Removed fallback warning deduplication and related state
- Removed unused in-service bandwidth state cache APIs
- Updated `DockerStatsTask` to always use Docker API network stats
- Narrowed `networkStatsSource` to `"docker"`
- Kept the existing bandwidth limit config flow and lifecycle integration unchanged

### Validation

- Daemon build passed
- Frontend type-check passed

---

## 最终结论

本次提交不是新增功能，而是一次 **实现收敛与职责精简**：

- **保留核心限速能力**
- **删除非必要监控机制**
- **统一统计来源**
- **降低复杂度与维护成本**
