### PR TITLE
fix: properly await disk check concurrency and avoid hanging checking flag

### DIFF
--- a/daemon/src/service/disk_limit_service.ts
+++ b/daemon/src/service/disk_limit_service.ts
@@ -44,13 +44,18 @@ class DiskLimitService {
   async #startCheck() {
     if (this.checking) return;
     this.checking = true;
-    for (let i = 0; i < this.concurrent; i++) {
-      const item = this.queue.pop();
-      if (item) {
-        this.checkDiskNow(item);
+    try {
+      const promises = [];
+      for (let i = 0; i < this.concurrent; i++) {
+        const item = this.queue.pop();
+        if (item) {
+          promises.push(this.checkDiskNow(item));
+        }
       }
+      await Promise.all(promises);
+    } finally {
+      this.checking = false;
     }
-    this.checking = false;
   }
 
   async #stopInstance(instance: Instance) {


### PR DESCRIPTION
## Description
Fix async concurrency bug in `#startCheck` where operations weren't properly awaited.

**Problem:**
- Called `checkDiskNow` without `await`
- Caused concurrency control failure

**Fix:**
- Collect promises and use `Promise.all`
- Add `try/finally` to always reset `checking` state