### PR TITLE
Fixed a language mistake where Success & Error were swapped in the Login widget

### DIFF
--- a/frontend/src/widgets/StatusBlock.vue
+++ b/frontend/src/widgets/StatusBlock.vue
@@ -166,11 +166,11 @@ const systemBars = computed(() => {
       <template v-else-if="realStatus?.type === 'users'">
         <div class="status-tags status-tags--wrap">
           <a-tag color="red">
-            <span class="status-tag-label">{{ t("TXT_CODE_43fcaf94") }}</span>
+            <span class="status-tag-label">{{ t("TXT_CODE_ac405b50") }}</span>
             <span class="status-tag-value">{{ realStatus.loginFailed }}</span>
           </a-tag>
           <a-tag color="green">
-            <span class="status-tag-label">{{ t("TXT_CODE_ac405b50") }}</span>
+            <span class="status-tag-label">{{ t("TXT_CODE_43fcaf94") }}</span>
             <span class="status-tag-value">{{ realStatus.logined }}</span>
           </a-tag>
         </div>


### PR DESCRIPTION
Fixes https://discord.com/channels/1005286077474557982/1483562399742169120/1483562399742169120