### PR TITLE
feat: 支持 MCDR 实例自动解析底层服务端类型与路径

### DIFF
--- a/daemon/src/entity/commands/dispatcher.ts
+++ b/daemon/src/entity/commands/dispatcher.ts
@@ -77,7 +77,7 @@ export default class FunctionDispatcher extends InstanceCommand {
     }
 
     // Minecraft Ping
-    if (instance.config.type.includes(Instance.TYPE_MINECRAFT_JAVA)) {
+    if (instance.effectiveType().includes(Instance.TYPE_MINECRAFT_JAVA)) {
       instance.setPreset("refreshPlayers", new PingJavaMinecraftServerCommand());
       instance.lifeCycleTaskManager.registerLifeCycleTask(new PingMinecraftServerTask());
     }

--- a/daemon/src/entity/instance/instance.ts
+++ b/daemon/src/entity/instance/instance.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "crypto";
 import { EventEmitter } from "events";
 import { t } from "i18next";
+import fs from "fs-extra";
 import iconv from "iconv-lite";
 import { configureEntityParams } from "mcsmanager-common";
 import path from "path";
@@ -9,6 +10,7 @@ import StorageSubsystem from "../../common/system_storage";
 import { STEAM_CMD_PATH } from "../../const";
 import { $t } from "../../i18n";
 import javaManager from "../../service/java_manager";
+import { resolveMCDRRuntime } from "../../service/mcdr_service";
 import logger from "../../service/log";
 import InstanceCommand from "../commands/base/command";
 import { commandStringToArray } from "../commands/base/command_parser";
@@ -480,6 +482,18 @@ export default class Instance extends EventEmitter {
     if (!this.config || !this.config.cwd) throw new Error("Instance config error, cwd is Null!");
     if (path.isAbsolute(this.config.cwd)) return path.normalize(this.config.cwd);
     return path.normalize(path.join(process.cwd(), this.config.cwd));
+  }
+
+  effectiveType(): string {
+    return resolveMCDRRuntime(this)?.mcdrType || this.config.type;
+  }
+
+  effectiveCwdPath(): string {
+    const mcdr = resolveMCDRRuntime(this);
+    if (mcdr && fs.existsSync(mcdr.mcdrRoot)) {
+      return mcdr.mcdrRoot;
+    }
+    return this.absoluteCwdPath();
   }
 
   // execute the preset command action

--- a/daemon/src/routers/Instance_router.ts
+++ b/daemon/src/routers/Instance_router.ts
@@ -93,7 +93,8 @@ routerApp.on("instance/select", (ctx, data) => {
       autoRestarted: instance.autoRestartCount,
       status: instance.status(),
       config: instance.config,
-      info: instance.info
+      info: instance.info,
+      effectiveType: instance.effectiveType()
     });
   });
 
@@ -116,7 +117,8 @@ routerApp.on("instance/overview", (ctx) => {
       autoRestarted: instance.autoRestartCount,
       status: instance.status(),
       config: instance.config,
-      info: instance.info
+      info: instance.info,
+      effectiveType: instance.effectiveType()
     });
   });
 
@@ -136,7 +138,8 @@ routerApp.on("instance/section", (ctx, data) => {
           autoRestarted: instance.autoRestartCount,
           status: instance.status(),
           config: instance.config,
-          info: instance.info
+          info: instance.info,
+          effectiveType: instance.effectiveType()
         });
       }
     });
@@ -163,6 +166,7 @@ routerApp.on("instance/detail", async (ctx, data) => {
       status: instance.status(),
       config: instance.config,
       info: instance.info,
+      effectiveType: instance.effectiveType(),
       space,
       processInfo
     });
@@ -501,7 +505,7 @@ routerApp.on("instance/process_config/list", (ctx, data) => {
   try {
     const instance = InstanceSubsystem.getInstance(instanceUuid);
     if (!instance) throw new Error($t("TXT_CODE_3bfb9e04"));
-    const fileManager = new FileManager(instance.absoluteCwdPath());
+    const fileManager = new FileManager(instance.effectiveCwdPath());
     for (const filePath of files) {
       if (fileManager.check(filePath)) {
         result.push({
@@ -525,9 +529,9 @@ routerApp.on("instance/process_config/file", (ctx, data) => {
   try {
     const instance = InstanceSubsystem.getInstance(instanceUuid);
     if (!instance) throw new Error($t("TXT_CODE_3bfb9e04"));
-    const fileManager = new FileManager(instance.absoluteCwdPath());
+    const fileManager = new FileManager(instance.effectiveCwdPath());
     if (!fileManager.check(fileName)) throw new Error($t("TXT_CODE_Instance_router.accessFileErr"));
-    const filePath = path.normalize(path.join(instance.absoluteCwdPath(), fileName));
+    const filePath = path.normalize(path.join(instance.effectiveCwdPath(), fileName));
     const processConfig = new ProcessConfig({
       fileName: fileName,
       redirect: fileName,

--- a/daemon/src/routers/stream_router.ts
+++ b/daemon/src/routers/stream_router.ts
@@ -70,6 +70,7 @@ routerApp.on("stream/detail", async (ctx) => {
       status: instance.status(),
       config: instance.config,
       info: instance.info,
+      effectiveType: instance.effectiveType(),
       watcher: instance.watchers.size
     });
   } catch (error: any) {

--- a/daemon/src/service/file_router_service.ts
+++ b/daemon/src/service/file_router_service.ts
@@ -4,13 +4,14 @@ import InstanceSubsystem from "../service/system_instance";
 import FileManager from "./system_file";
 import os from "os";
 
-export function getFileManager(instanceUuid: string) {
+export function getFileManager(instanceUuid: string, options?: { useServerRoot?: boolean }) {
   // Initialize a file manager for the instance, and assign codes, restrictions, etc.
   const instance = InstanceSubsystem.getInstance(instanceUuid);
   if (!instance)
     throw new Error($t("TXT_CODE_file_router_service.instanceNotExit", { uuid: instanceUuid }));
   const fileCode = instance.config?.fileCode;
-  return new FileManager(instance.absoluteCwdPath(), fileCode);
+  const rootPath = options?.useServerRoot ? instance.effectiveCwdPath() : instance.absoluteCwdPath();
+  return new FileManager(rootPath, fileCode);
 }
 
 let cacheDisks: string[] = [];

--- a/daemon/src/service/interfaces.ts
+++ b/daemon/src/service/interfaces.ts
@@ -6,6 +6,7 @@ export interface IInstanceDetail {
   status: number;
   config: InstanceConfig;
   info?: any;
+  effectiveType?: string;
 }
 
 export interface IJson<T> {

--- a/daemon/src/service/mcdr_service.ts
+++ b/daemon/src/service/mcdr_service.ts
@@ -1,4 +1,4 @@
-import fs from "fs-extra";
+import fs from "fs";
 import path from "path";
 import { ProcessConfig } from "../entity/instance/process_config";
 
@@ -29,6 +29,14 @@ const MCDR_HANDLER_TYPE_MAP: Record<string, string> = {
 const MCDR_CONFIG_FILES = ["config.yml", "config.yaml"];
 
 const cache = new Map<string, { mtime: number; result: IMCDRRuntime | null }>();
+const MAX_CACHE_SIZE = 256;
+
+function setCache(filePath: string, mtime: number, result: IMCDRRuntime | null) {
+    cache.delete(filePath);
+    cache.set(filePath, { mtime, result });
+    const oldestKey = cache.size > MAX_CACHE_SIZE ? cache.keys().next().value : undefined;
+    if (oldestKey) cache.delete(oldestKey);
+}
 
 export function resolveMCDRRuntime(instance: IMCDRResolvable): IMCDRRuntime | null {
     if (instance.config.type !== "universal/mcdr") return null;
@@ -37,7 +45,10 @@ export function resolveMCDRRuntime(instance: IMCDRResolvable): IMCDRRuntime | nu
 
     for (const fileName of MCDR_CONFIG_FILES) {
         const filePath = path.join(instanceRoot, fileName);
-        if (!fs.existsSync(filePath)) continue;
+        if (!fs.existsSync(filePath)) {
+            cache.delete(filePath);
+            continue;
+        }
 
         try {
             const stat = fs.statSync(filePath);
@@ -67,7 +78,7 @@ export function resolveMCDRRuntime(instance: IMCDRResolvable): IMCDRRuntime | nu
 
             const relative = path.relative(instanceRoot, resolvedRoot);
             if (relative.startsWith("..") || path.isAbsolute(relative)) {
-                cache.set(filePath, { mtime, result: null });
+                setCache(filePath, mtime, null);
                 return null;
             }
 
@@ -75,7 +86,7 @@ export function resolveMCDRRuntime(instance: IMCDRResolvable): IMCDRRuntime | nu
                 mcdrType: resolvedType,
                 mcdrRoot: resolvedRoot
             };
-            cache.set(filePath, { mtime, result });
+            setCache(filePath, mtime, result);
             return result;
         } catch (error) {
             continue;

--- a/daemon/src/service/mcdr_service.ts
+++ b/daemon/src/service/mcdr_service.ts
@@ -1,0 +1,86 @@
+import fs from "fs-extra";
+import path from "path";
+import { ProcessConfig } from "../entity/instance/process_config";
+
+export interface IMCDRRuntime {
+    mcdrType: string;
+    mcdrRoot: string;
+}
+
+interface IMCDRResolvable {
+    config: { type: string };
+    absoluteCwdPath(): string;
+}
+
+const MCDR_HANDLER_TYPE_MAP: Record<string, string> = {
+    vanilla_handler: "minecraft/java",
+    beta18_handler: "minecraft/java",
+    bukkit_handler: "minecraft/java/bukkit",
+    bukkit14_handler: "minecraft/java/bukkit",
+    bungeecord_handler: "minecraft/java/bungeecord",
+    cat_server_handler: "minecraft/java/forge",
+    arclight_handler: "minecraft/java/forge",
+    forge_handler: "minecraft/java/forge",
+    fabric_handler: "minecraft/java/fabric",
+    velocity_handler: "minecraft/java/velocity",
+    waterfall_handler: "minecraft/java/bungeecord",
+};
+
+const MCDR_CONFIG_FILES = ["config.yml", "config.yaml"];
+
+const cache = new Map<string, { mtime: number; result: IMCDRRuntime | null }>();
+
+export function resolveMCDRRuntime(instance: IMCDRResolvable): IMCDRRuntime | null {
+    if (instance.config.type !== "universal/mcdr") return null;
+
+    const instanceRoot = instance.absoluteCwdPath();
+
+    for (const fileName of MCDR_CONFIG_FILES) {
+        const filePath = path.join(instanceRoot, fileName);
+        if (!fs.existsSync(filePath)) continue;
+
+        try {
+            const stat = fs.statSync(filePath);
+            const mtime = stat.mtimeMs;
+            const cached = cache.get(filePath);
+            if (cached && cached.mtime === mtime) return cached.result;
+
+            const processConfig = new ProcessConfig({
+                fileName,
+                redirect: fileName,
+                path: filePath,
+                type: "yml",
+                info: null,
+                fromLink: null
+            });
+            const config = processConfig.read();
+            const handler = typeof config?.handler === "string" ? config.handler.trim().toLowerCase() : "";
+            const workingDirectory =
+                typeof config?.working_directory === "string" ? config.working_directory.trim() : "";
+            const resolvedType = MCDR_HANDLER_TYPE_MAP[handler];
+
+            if (!resolvedType || !workingDirectory) continue;
+
+            const resolvedRoot = path.isAbsolute(workingDirectory)
+                ? path.normalize(workingDirectory)
+                : path.normalize(path.join(instanceRoot, workingDirectory));
+
+            const relative = path.relative(instanceRoot, resolvedRoot);
+            if (relative.startsWith("..") || path.isAbsolute(relative)) {
+                cache.set(filePath, { mtime, result: null });
+                return null;
+            }
+
+            const result: IMCDRRuntime = {
+                mcdrType: resolvedType,
+                mcdrRoot: resolvedRoot
+            };
+            cache.set(filePath, { mtime, result });
+            return result;
+        } catch (error) {
+            continue;
+        }
+    }
+
+    return null;
+}

--- a/daemon/src/service/mod_service.ts
+++ b/daemon/src/service/mod_service.ts
@@ -169,7 +169,7 @@ export class ModService {
     if (pageSize < 1) pageSize = 10;
     if (page < 1) page = 1;
 
-    const fileManager = getFileManager(instanceUuid);
+    const fileManager = getFileManager(instanceUuid, { useServerRoot: true });
 
     // if (!FileManager.checkFileName(folder ?? "")) {
     //   throw new Error("Invalid folder name");
@@ -287,7 +287,7 @@ export class ModService {
   }
 
   public async toggleMod(instanceUuid: string, fileName: string): Promise<void> {
-    const fileManager = getFileManager(instanceUuid);
+    const fileManager = getFileManager(instanceUuid, { useServerRoot: true });
     if (!fileManager.checkPath(fileName)) throw new Error("Invalid file name");
     const rootDir = fileManager.toAbsolutePath(".");
 
@@ -317,7 +317,7 @@ export class ModService {
   }
 
   public async deleteMod(instanceUuid: string, fileName: string): Promise<void> {
-    const fileManager = getFileManager(instanceUuid);
+    const fileManager = getFileManager(instanceUuid, { useServerRoot: true });
     if (!fileManager.checkPath(fileName)) throw new Error("Invalid file name");
     const rootDir = fileManager.toAbsolutePath(".");
 
@@ -346,7 +346,7 @@ export class ModService {
     type: "mod" | "plugin",
     options: { fallbackUrl?: string } = {}
   ) {
-    const fileManager = getFileManager(instanceUuid);
+    const fileManager = getFileManager(instanceUuid, { useServerRoot: true });
     const rootDir = fileManager.toAbsolutePath(".");
 
     // Determine the save directory based on what exists (case-sensitive check for Linux)
@@ -378,7 +378,7 @@ export class ModService {
     type: "mod" | "plugin",
     fileName?: string
   ): Promise<ModConfigFile[]> {
-    const fileManager = getFileManager(instanceUuid);
+    const fileManager = getFileManager(instanceUuid, { useServerRoot: true });
     if (fileName && !fileManager.checkPath(fileName)) throw new Error("Invalid file name");
     if (modId && !fileManager.checkPath(modId)) throw new Error("Invalid mod ID");
     const rootDir = fileManager.toAbsolutePath(".");

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -57,6 +57,7 @@ export interface InstanceDetail {
   status: INSTANCE_STATUS_CODE;
   info: InstanceRuntimeInfo;
   config: IGlobalInstanceConfig;
+  effectiveType?: string;
   watcher?: number;
 }
 

--- a/frontend/src/widgets/instance/ManagerBtns.vue
+++ b/frontend/src/widgets/instance/ManagerBtns.vue
@@ -134,7 +134,7 @@ const btns = computed(() => {
         toPage({
           path: "/instances/terminal/serverConfig",
           query: {
-            type: instanceInfo.value?.config.type
+            type: instanceInfo.value?.effectiveType || instanceInfo.value?.config.type
           }
         });
       }
@@ -154,7 +154,7 @@ const btns = computed(() => {
         toPage({ path: "/instances/terminal/mods" });
       },
       condition: () => {
-        const type = instanceInfo.value?.config.type || "";
+        const type = instanceInfo.value?.effectiveType || instanceInfo.value?.config.type || "";
         // Narrow it down to Minecraft server types only (Java or Bedrock)
         const isMC = type.startsWith("minecraft/java") || type.startsWith("minecraft/bedrock");
         if (!isMC) return false;
@@ -171,10 +171,13 @@ const btns = computed(() => {
       click: () => {
         javaManagerDialog.value?.openDialog();
       },
-      condition: () =>
-        (instanceInfo.value?.config.type.includes(TYPE_MINECRAFT_JAVA) &&
-          instanceInfo.value?.config.processType === "general") ??
-        false
+      condition: () => {
+        return (
+          (instanceInfo.value?.effectiveType || instanceInfo.value?.config.type || "").includes(
+            TYPE_MINECRAFT_JAVA
+          ) && instanceInfo.value?.config.processType === "general"
+        );
+      }
     },
     {
       title: t("TXT_CODE_656a85d8"),
@@ -182,8 +185,13 @@ const btns = computed(() => {
       click: () => {
         rconSettingsDialog.value?.openDialog();
       },
-      condition: () =>
-        instanceInfo.value?.config.type.includes(TYPE_STEAM_SERVER_UNIVERSAL) ?? false
+      condition: () => {
+        return (
+          instanceInfo.value?.effectiveType ||
+          instanceInfo.value?.config.type ||
+          ""
+        ).includes(TYPE_STEAM_SERVER_UNIVERSAL);
+      }
     },
 
     {
@@ -228,7 +236,13 @@ const btns = computed(() => {
       click: () => {
         mcSettingsDialog.value?.openDialog();
       },
-      condition: () => instanceInfo.value?.config.type.includes(TYPE_MINECRAFT_JAVA) ?? false
+      condition: () => {
+        return (
+          instanceInfo.value?.effectiveType ||
+          instanceInfo.value?.config.type ||
+          ""
+        ).includes(TYPE_MINECRAFT_JAVA);
+      }
     },
     {
       title: t("TXT_CODE_4f34fc28"),
@@ -244,9 +258,13 @@ const btns = computed(() => {
   ]);
 });
 
-watch(instanceInfo, (cfg, oldCfg) => {
-  if (cfg?.config?.type && instanceId && daemonId && cfg.config.type !== oldCfg?.config?.type) {
-    refreshServerConfig(cfg.config.type, instanceId, daemonId);
+const instanceType = computed(() => {
+  return instanceInfo.value?.effectiveType || instanceInfo.value?.config.type;
+});
+
+watch(instanceType, (type, oldType) => {
+  if (type && instanceId && daemonId && type !== oldType) {
+    refreshServerConfig(type as string, instanceId as string, daemonId as string);
   }
 });
 </script>

--- a/frontend/src/widgets/instance/ManagerBtns.vue
+++ b/frontend/src/widgets/instance/ManagerBtns.vue
@@ -117,6 +117,10 @@ const refreshInstanceInfo = async () => {
   });
 };
 
+const instanceType = computed(() => {
+  return instanceInfo.value?.effectiveType || instanceInfo.value?.config.type;
+});
+
 const btns = computed(() => {
   if (!instanceInfo.value) return [];
   return arrayFilter([
@@ -134,7 +138,7 @@ const btns = computed(() => {
         toPage({
           path: "/instances/terminal/serverConfig",
           query: {
-            type: instanceInfo.value?.effectiveType || instanceInfo.value?.config.type
+            type: instanceType.value
           }
         });
       }
@@ -154,7 +158,7 @@ const btns = computed(() => {
         toPage({ path: "/instances/terminal/mods" });
       },
       condition: () => {
-        const type = instanceInfo.value?.effectiveType || instanceInfo.value?.config.type || "";
+        const type = instanceType.value || "";
         // Narrow it down to Minecraft server types only (Java or Bedrock)
         const isMC = type.startsWith("minecraft/java") || type.startsWith("minecraft/bedrock");
         if (!isMC) return false;
@@ -173,9 +177,8 @@ const btns = computed(() => {
       },
       condition: () => {
         return (
-          (instanceInfo.value?.effectiveType || instanceInfo.value?.config.type || "").includes(
-            TYPE_MINECRAFT_JAVA
-          ) && instanceInfo.value?.config.processType === "general"
+          (instanceType.value || "").includes(TYPE_MINECRAFT_JAVA) &&
+          instanceInfo.value?.config.processType === "general"
         );
       }
     },
@@ -186,11 +189,7 @@ const btns = computed(() => {
         rconSettingsDialog.value?.openDialog();
       },
       condition: () => {
-        return (
-          instanceInfo.value?.effectiveType ||
-          instanceInfo.value?.config.type ||
-          ""
-        ).includes(TYPE_STEAM_SERVER_UNIVERSAL);
+        return (instanceType.value || "").includes(TYPE_STEAM_SERVER_UNIVERSAL);
       }
     },
 
@@ -237,11 +236,7 @@ const btns = computed(() => {
         mcSettingsDialog.value?.openDialog();
       },
       condition: () => {
-        return (
-          instanceInfo.value?.effectiveType ||
-          instanceInfo.value?.config.type ||
-          ""
-        ).includes(TYPE_MINECRAFT_JAVA);
+        return (instanceType.value || "").includes(TYPE_MINECRAFT_JAVA);
       }
     },
     {
@@ -256,10 +251,6 @@ const btns = computed(() => {
       }
     }
   ]);
-});
-
-const instanceType = computed(() => {
-  return instanceInfo.value?.effectiveType || instanceInfo.value?.config.type;
 });
 
 watch(instanceType, (type, oldType) => {

--- a/frontend/src/widgets/instance/Terminal.vue
+++ b/frontend/src/widgets/instance/Terminal.vue
@@ -78,7 +78,8 @@ const toOpenInstance = async () => {
   if (checkRunningTimer) clearTimeout(checkRunningTimer);
   clearTerminal();
   try {
-    if (instanceInfo.value?.config?.type?.startsWith("minecraft/java")) {
+    const instanceType = instanceInfo.value?.effectiveType || instanceInfo.value?.config.type || "";
+    if (instanceType.startsWith("minecraft/java")) {
       const flag = await verifyEULA(instanceId ?? "", daemonId ?? "");
       if (!flag) return;
       await sleep(1000);


### PR DESCRIPTION
在 `Instance` 实体中封装 `effectiveType()` 和 `effectiveCwdPath()` 方法，通过自动解析 MCDR 的 `config.yml` 路径，使 MCDR 实例能够直接复用其子服务端的 Mod 管理、配置修改、EULA 检查等功能，而无需修改现有业务逻辑。

close #2089.

```mermaid
flowchart LR
    A[MCDR 实例] --> B[Daemon 解析 MCDR 配置]
    B --> C[effectiveType]
    B --> D[effectiveCwdPath]
    
    C --> E[复用现有 Java 服务端逻辑]
    D --> E
    
    C --> F[前端功能按钮显隐判断]
    D --> F[特定配置/Mod 路径重定向]
```