### PR TITLE
fix auth_router.ts

### DIFF
--- a/daemon/src/routers/auth_router.ts
+++ b/daemon/src/routers/auth_router.ts
@@ -55,8 +55,8 @@ routerApp.on("auth", (ctx, data) => {
       (!globalConfiguration.config.whiteListPanelIp ||
         globalConfiguration.config.whiteListPanelIps.includes(ip)) &&
       timingSafeEqual(
-        Uint8Array.from(String(data ?? "")),
-        Uint8Array.from(String(globalConfiguration.config.key ?? ""))
+        Buffer.from(String(data ?? "")),
+        Buffer.from(String(globalConfiguration.config.key ?? ""))
       )
     ) {
       // The authentication is passed, and the registered session is a trusted session


### PR DESCRIPTION
Modify `Uint8Array.from` to `Buffer.from`

```js
Welcome to Node.js v24.14.1.
Type ".help" for more information.

> const { timingSafeEqual } = require('node:crypto')
undefined

> const a = [0, 0].map(() => crypto.randomUUID().replaceAll('-', '')).join('').slice(0, 47)
undefined
> a
'fa9aaf105f9e47ee89d434af830be3267dfa414e5e37459'

> const b = a.replace(/[^0-9]/g, '0')
undefined
> b
'00900010509047008904340083000326700041405037459'

> Uint8Array.from(a) // wrong
Uint8Array(47) [
  0, 0, 9, 0, 0, 0, 1, 0, 5, 0, 9,
  0, 4, 7, 0, 0, 8, 9, 0, 4, 3, 4,
  0, 0, 8, 3, 0, 0, 0, 3, 2, 6, 7,
  0, 0, 0, 4, 1, 4, 0, 5, 0, 3, 7,
  4, 5, 9
]
> timingSafeEqual(Uint8Array.from(a), Uint8Array.from(b)) // wrong
true

> Buffer.from(a) // right
<Buffer 66 61 39 61 61 66 31 30 35 66 39 65 34 37 65 65 38 39 64 34 33 34 61 66 38 33 30 62 65 33 32 36 37 64 66 61 34 31 34 65 35 65 33 37 34 35 39>
> timingSafeEqual(Buffer.from(a), Buffer.from(b)) // right
false
> timingSafeEqual(Buffer.from(a), Buffer.from(a)) // right
true
```