### PR TITLE
fix: handle PTY toggle errors while instance is running

### DIFF
--- a/frontend/src/widgets/instance/dialogs/TermConfig.vue
+++ b/frontend/src/widgets/instance/dialogs/TermConfig.vue
@@ -6,7 +6,7 @@ import type { InstanceDetail } from "@/types";
 import { updateInstanceConfig } from "@/services/apis/instance";
 import { message } from "ant-design-vue";
 import { reportErrorMsg } from "@/tools/validator";
-import { TERMINAL_CODE } from "@/types/const";
+import { INSTANCE_STATUS_CODE, TERMINAL_CODE } from "@/types/const";
 
 const props = defineProps<{
   instanceInfo?: InstanceDetail;
@@ -15,6 +15,7 @@ const props = defineProps<{
 }>();
 const emit = defineEmits(["update"]);
 const options = ref<InstanceDetail>();
+const initialPty = ref<boolean>();
 
 const screen = useScreen();
 const isPhone = computed(() => screen.isPhone.value);
@@ -22,12 +23,28 @@ const open = ref(false);
 const openDialog = () => {
   open.value = true;
   options.value = props.instanceInfo;
+  initialPty.value = props.instanceInfo?.config.terminalOption?.pty;
 };
 
 const { execute, isLoading } = updateInstanceConfig();
 
+const isChangingPtyWhileRunning = () => {
+  const previousPty = initialPty.value;
+  const currentPty = options.value?.config.terminalOption?.pty;
+  if (previousPty === undefined || currentPty === undefined || previousPty === currentPty) {
+    return false;
+  }
+  const status = options.value?.status ?? props.instanceInfo?.status;
+  if (status === undefined) return false;
+  return status !== INSTANCE_STATUS_CODE.STOPPED && status !== INSTANCE_STATUS_CODE.BUSY;
+};
+
 const submit = async () => {
   try {
+    if (isChangingPtyWhileRunning()) {
+      return reportErrorMsg(t("TXT_CODE_instanceConf.cantModifyPtyModel"));
+    }
+
     await execute({
       params: {
         uuid: props.instanceId ?? "",

--- a/panel/src/app/routers/instance_operate_router.ts
+++ b/panel/src/app/routers/instance_operate_router.ts
@@ -463,7 +463,7 @@ router.put(
       let advancedConfig = {};
       advancedConfig = checkInstanceAdvancedParams(config, isTopPermission);
 
-      new RemoteRequest(remoteService).request("instance/update", {
+      await new RemoteRequest(remoteService).request("instance/update", {
         instanceUuid,
         config: {
           pingConfig: !isEmpty(config.pingConfig) ? pingConfig : null,


### PR DESCRIPTION
**Issue**
Changing `Emulated Terminal (PTY)` while an instance is running is blocked by daemon logic, but the panel route returned success too early.  
This caused inconsistent UX and server logs like:

`ERROR (unhandledRejection): RemoteError: PTY mode cannot be modified while running.`

**How to Reproduce**
1. Start an instance.
2. Open **Terminal Settings**.
3. Toggle **Emulated Terminal (PTY)**.
4. Click **Save**.

**Actual Result**
- Backend can throw `PTY mode cannot be modified while running`.
- Panel may still return success due to missing `await`.
- User feedback is unclear/inconsistent, and unhandled rejection appears in logs.

**Expected Result**
- User should immediately see an error message:
  `The PTY mode cannot be modified while running.`
- No false success result.
- No unhandled rejection for this action.

**Fix**
- Backend: in `panel/src/app/routers/instance_operate_router.ts`, add `await` to the `instance/update` remote request inside `/protected_instance/instance_update` so daemon errors are caught and returned normally.
- Frontend: in `frontend/src/widgets/instance/dialogs/TermConfig.vue`, store original PTY value and block submit when PTY is changed while status is not `STOPPED`/`BUSY`, then show `TXT_CODE_instanceConf.cantModifyPtyModel`.
- Keep other terminal settings editable while running when PTY itself is unchanged.