### PR TITLE
fix(i18n): register Turkish locale in panel and daemon

### DIFF
--- a/daemon/src/i18n/index.ts
+++ b/daemon/src/i18n/index.ts
@@ -14,6 +14,7 @@ import ko_KR from "@languages/ko_KR.json";
 import de_DE from "@languages/de_DE.json";
 import pt_BR from "@languages/pt_BR.json";
 import th_TH from "@languages/th_TH.json";
+import tr_TR from "@languages/tr_TR.json";
 
 i18next.init({
   interpolation: {
@@ -54,6 +55,9 @@ i18next.init({
     },
     th_th: {
       translation: th_TH
+    },
+    tr_tr: {
+      translation: tr_TR
     }
   }
 });

--- a/panel/src/app/i18n/index.ts
+++ b/panel/src/app/i18n/index.ts
@@ -14,6 +14,7 @@ import ko_KR from "@languages/ko_KR.json";
 import de_DE from "@languages/de_DE.json";
 import pt_BR from "@languages/pt_BR.json";
 import th_TH from "@languages/th_TH.json";
+import tr_TR from "@languages/tr_TR.json";
 
 i18next.init({
   interpolation: {
@@ -54,6 +55,9 @@ i18next.init({
     },
     th_TH: {
       translation: th_TH
+    },
+    tr_tr: {
+      translation: tr_TR
     }
   }
 });


### PR DESCRIPTION
## Summary
- Add `tr_TR` language import to panel i18n initialization.
- Add `tr_TR` language import to daemon i18n initialization.
- Register Turkish translations under `tr_tr` in both runtime i18n resource maps.
- Keep existing translation files and auto-translate mappings unchanged.

## Why
`languages/tr_TR.json` already exists, but Turkish was not registered in runtime i18n, so it was effectively unused.

## Related issue
- https://discord.com/channels/1005286077474557982/1239542299797622784/1444619294657740872
> Hello, when I set the language of the panel to tr_TR and run the panel from the config, it becomes English. How can I change it to Turkish?