### PR TITLE
fix(image-manager): remove misleading Stop button from Build Progress modal

### DIFF
--- a/frontend/src/widgets/imageManager/BuildProgress.vue
+++ b/frontend/src/widgets/imageManager/BuildProgress.vue
@@ -79,7 +79,6 @@ defineExpose({
     <template #footer>
       <a-space>
         <a-button :loading="isLoading" @click="getProgress">{{ t("TXT_CODE_b76d94e0") }}</a-button>
-        <a-button type="primary" @click="open = false">{{ t("TXT_CODE_b1dedda3") }}</a-button>
       </a-space>
     </template>
   </a-modal>


### PR DESCRIPTION
## Summary
The Build Progress modal showed a primary `Stop` button, but clicking it only closed the modal. This is misleading and redundant because the modal already has a close (`X`) control.

## Changes
- Removed the footer close button from `frontend/src/widgets/imageManager/BuildProgress.vue`
- Kept the `Refresh` button as the only footer action

## Behavior After Change
- Users can still close the modal via the top-right `X` / standard modal close behavior
- No fake "Stop" action is shown anymore

## Screenshot
<img width="1412" height="627" alt="image" src="https://github.com/user-attachments/assets/2e87de30-fbaf-457d-a6d8-1c9b4eb939a7" />
