### PR TITLE
fix: remove tags when switching nodes

### DIFF
--- a/frontend/src/widgets/InstanceList.vue
+++ b/frontend/src/widgets/InstanceList.vue
@@ -134,6 +134,7 @@ const toAppDetailPage = (daemonId: string, instanceId: string) => {
 const handleChangeNode = async (item: NodeStatus) => {
   try {
     currentRemoteNode.value = item;
+    clearTags();
     selectedInstance.value = [];
     await initInstancesData(true);
     localStorage.setItem("pageSelectedRemote", JSON.stringify(item));


### PR DESCRIPTION
### BUG

当从一个有已选标签的节点切换到另一个节点时，URL会携带已选的标签。如果目标节点没有标签，这将导致切换后没有实例显示，并且也无法清除已选的标签
When switching from a node with selected tags to another node, the URL will carry over the selected tags. If the target node has no tags, this will result in no instances being displayed after the switch, and it will also be impossible to clear the selected tags.

---

**Before Fix**
<img width="480" height="164" alt="image" src="https://github.com/user-attachments/assets/21e817a5-ac17-4b1b-8b7f-fcf49c1df45b" />
tag=["正常"]

**After Fix**
<img width="479" height="144" alt="image" src="https://github.com/user-attachments/assets/e86e47c2-bcec-48cd-adc3-4f0b2b9532e5" />
tag=[]
