### PR TITLE
fix: redirect authenticated users away from login page

### DIFF
--- a/frontend/src/config/router.ts
+++ b/frontend/src/config/router.ts
@@ -394,6 +394,10 @@ router.beforeEach(async (to, from, next) => {
     }
   }
 
+  if (toRoutePath === "/login" && state.userInfo?.token) {
+    return next(isAdmin.value ? "/" : "/customer");
+  }
+
   if (
     toRoutePath.includes("_open_page") ||
     toRoutePath.startsWith("/sso/") ||


### PR DESCRIPTION
**ISSUE**

已登录用户再次访问login路由仍会弹出登录窗口，没有跳转到实例界面，此现象可能会误导用户
Authenticated users could still open the login page by visiting the login route directly, which may make them think their session has expired.

<img width="318" height="44" alt="image" src="https://github.com/user-attachments/assets/36ec9ab3-e490-4fb2-9c8c-cfa847dfc6dd" />

---

**FIX**

修复后，已登录用户访问login路由时，会根据用户权限跳转到管理员首页或普通用户页面；未登录用户仍可正常访问登录页。
Added a router guard check to redirect authenticated users away from `/login` to the admin home page or customer page based on their role. Unauthenticated users can still access the login page normally.

<img width="325" height="125" alt="image" src="https://github.com/user-attachments/assets/9d3e58e1-fee5-46d3-94c4-b40ab92bcdba" />

