### PR TITLE
fix: clean up Linux instance child processes on shutdown

### DIFF
--- a/common/src/process_tools.ts
+++ b/common/src/process_tools.ts
@@ -1,4 +1,5 @@
 import { ChildProcess, exec, execSync, SpawnOptionsWithoutStdio } from "child_process";
+import fs from "fs";
 import os from "os";
 import child_process from "child_process";
 import path from "path";
@@ -130,11 +131,62 @@ export function killProcess(
       return true;
     }
     if (os.platform() === "linux") {
-      execSync(`kill -s 9 ${pid}`);
+      killLinuxProcessTree(pid);
       return true;
     }
   } catch (err) {
     return signal ? process.kill(signal) : process.kill("SIGKILL");
   }
   return signal ? process.kill(signal) : process.kill("SIGKILL");
+}
+
+function killLinuxProcessTree(pid: string | number) {
+  const targetPid = Number(pid);
+  const childPids = collectLinuxChildPids(targetPid);
+
+  for (const childPid of childPids) {
+    execSync(`kill -s 9 ${childPid}`);
+  }
+
+  execSync(`kill -s 9 ${targetPid}`);
+}
+
+function collectLinuxChildPids(pid: number): number[] {
+  const childPids = listLinuxChildPids(pid);
+  const result: number[] = [];
+
+  for (const childPid of childPids) {
+    result.push(...collectLinuxChildPids(childPid));
+    result.push(childPid);
+  }
+
+  return result;
+}
+
+function listLinuxChildPids(pid: number): number[] {
+  const procChildren = readLinuxChildrenFromProc(pid);
+  if (procChildren) return procChildren;
+
+  try {
+    const output = execSync(`ps -o pid= --ppid ${pid}`, { encoding: "utf-8" });
+    return String(output)
+      .split(/\s+/)
+      .map((item) => Number(item.trim()))
+      .filter((item) => Number.isInteger(item) && item > 0);
+  } catch (error) {
+    return [];
+  }
+}
+
+function readLinuxChildrenFromProc(pid: number): number[] | null {
+  try {
+    const childrenPath = `/proc/${pid}/task/${pid}/children`;
+    const output = fs.readFileSync(childrenPath, { encoding: "utf-8" });
+    return String(output)
+      .split(/\s+/)
+      .map((item) => Number(item.trim()))
+      .filter((item) => Number.isInteger(item) && item > 0);
+  } catch (error) {
+    return null;
+  }
 }


### PR DESCRIPTION
**BUG**

#2106 

在linux上关闭实例时，若关闭命令为 `^c` ，信号可能只会作用到使用启动命令启动的主进程，若主进程生成了子进程，可能就会导致子进程变成孤儿进程。

其原因是：在 `killProcess()` 中，linux系统所使用的 `kill -s 9 ${pid}` 无法杀死整个进程树，而windows所使用的 `taskkill /PID ${pid} /T /F` 可以终止整个进程树

所以我修改了清理路径：
- 优先使用 `/proc/<pid>/task/<pid>/children` 获取所有子进程
- 若不可用，则使用 `ps -o pid= --ppid <pid>` 
- 都不可用就退回到最初的 `kill -s 9 ${pid}`

When shutting down an instance on Linux, if the shutdown command is `^c`, the signal may only affect the main process started by the startup command. If the main process has spawned child processes, this could result in the child processes becoming orphaned.

The reason is: in killProcess(), the Linux system uses `kill -s 9 ${pid}`, which cannot kill the entire process tree, whereas Windows uses `taskkill /PID ${pid} /T /F`, which can terminate the entire process tree.

Therefore, I modified the cleanup procedure:

- First, use `/proc/<pid>/task/<pid>/children` to get all child processes.
- If not available, use `ps -o pid= --ppid <pid>`.
- If both are unavailable, fall back to the original `kill -s 9 ${pid}`. 

### BEFORE FIX
在17:14:24关闭实例
<img width="791" height="134" alt="image" src="https://github.com/user-attachments/assets/f8e4d1b8-d5cb-4665-b9e7-e8eb3734770f" />
日志显示子进程没有杀死，已成为孤儿进程
<img width="611" height="59" alt="image" src="https://github.com/user-attachments/assets/2ef3cc63-1ae8-426b-948a-f705f4f5d576" />

### AFTER FIX

<img width="1387" height="199" alt="image" src="https://github.com/user-attachments/assets/2ba0064e-0545-4a98-8084-3e204031303b" />

<img width="760" height="143" alt="image" src="https://github.com/user-attachments/assets/7f5373a7-b2f3-4532-9434-79469395c570" />

日志没有出现更多子进程日志，子进程也被成功杀死

---

只修复了非docker环境的关闭命令，因为不用docker实例我也不清楚他有没有相同问题，如果也有问题的话应该也可以用`proc`解决，但`ps`应该是用不了的，一般应该没内置这个命令