### PR TITLE
fix: 修复终端 emoji 宽度显示异常及实例列表标题溢出并优化终端复制逻辑

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,6 +28,7 @@
         "@vueuse/core": "^10.3.0",
         "@xterm/addon-canvas": "^0.7.0",
         "@xterm/addon-fit": "^0.10.0",
+        "@xterm/addon-unicode11": "^0.9.0",
         "@xterm/addon-webgl": "^0.18.0",
         "@xterm/xterm": "^5.5.0",
         "ant-design-vue": "^4.0.7",
@@ -2837,6 +2838,12 @@
       "peerDependencies": {
         "@xterm/xterm": "^5.0.0"
       }
+    },
+    "node_modules/@xterm/addon-unicode11": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-unicode11/-/addon-unicode11-0.9.0.tgz",
+      "integrity": "sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw==",
+      "license": "MIT"
     },
     "node_modules/@xterm/addon-webgl": {
       "version": "0.18.0",
@@ -12306,6 +12313,11 @@
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
       "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
       "requires": {}
+    },
+    "@xterm/addon-unicode11": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-unicode11/-/addon-unicode11-0.9.0.tgz",
+      "integrity": "sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw=="
     },
     "@xterm/addon-webgl": {
       "version": "0.18.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "@vueuse/core": "^10.3.0",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/addon-webgl": "^0.18.0",
     "@xterm/xterm": "^5.5.0",
     "ant-design-vue": "^4.0.7",

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -3,12 +3,14 @@ import { useCommandHistory } from "@/hooks/useCommandHistory";
 import { t } from "@/lang/i18n";
 import { setUpTerminalStreamChannel } from "@/services/apis/instance";
 import { useAppConfigStore } from "@/stores/useAppConfigStore";
+import { toCopy } from "@/tools/copy";
 import { mapDaemonAddress, parseForwardAddress } from "@/tools/protocol";
 import type { InstanceDetail } from "@/types";
 import { INSTANCE_STATUS_CODE } from "@/types/const";
 import type { DefaultEventsMap } from "@socket.io/component-emitter";
 import { CanvasAddon } from "@xterm/addon-canvas";
 import { FitAddon } from "@xterm/addon-fit";
+import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal } from "@xterm/xterm";
 import EventEmitter from "eventemitter3";
@@ -252,6 +254,10 @@ export function useTerminal() {
     const fitAddon = new FitAddon();
     term.loadAddon(fitAddon);
 
+    const unicode11Addon = new Unicode11Addon();
+    term.loadAddon(unicode11Addon);
+    term.unicode.activeVersion = "11";
+
     terminal.value = term;
 
     const gl = document.createElement("canvas").getContext("webgl2");
@@ -275,17 +281,10 @@ export function useTerminal() {
       if (arg.type === "keydown" && arg.ctrlKey && arg.code === "KeyC") {
         const selection = term.getSelection();
         if (selection) {
-          // If not in SecureContext, writeText will fail. Fallback to browser's default copy behavior, but selection won't be cleared.
-          if (window.isSecureContext) {
-            arg.preventDefault()
-          }
-
-          navigator.clipboard?.writeText(selection).then(() => {
-             term.clearSelection();
-          }).catch(err => {
-             console.error("Could not copy text: ", err);
-          });
-
+          arg.preventDefault();
+          // execCommand inside toCopy triggers xterm.js's copy event handler
+          toCopy(selection);
+          term.clearSelection();
           return false;
         }
       }

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -282,7 +282,6 @@ export function useTerminal() {
         const selection = term.getSelection();
         if (selection) {
           arg.preventDefault();
-          // execCommand inside toCopy triggers xterm.js's copy event handler
           toCopy(selection);
           term.clearSelection();
           return false;

--- a/frontend/src/widgets/instance/InstanceLine.vue
+++ b/frontend/src/widgets/instance/InstanceLine.vue
@@ -109,7 +109,7 @@ const toInstanceTerminal = async () => {
       <FrownOutlined v-else-if="node" style="margin-right: 8px" />
       <a v-if="!node" @click="toInstanceTerminal()">
         <a-typography-text
-          :style="{ fontWeight: 'normal', maxWidth: '200px' }"
+          :style="{ fontWeight: 'normal', maxWidth: '190px' }"
           :ellipsis="{ tooltip: record.name }"
           :content="record.name"
         />
@@ -125,8 +125,8 @@ const toInstanceTerminal = async () => {
           props.targetInstanceInfo?.status === INSTANCE_STATUS_CODE.RUNNING
             ? 'green'
             : props.targetInstanceInfo?.status === INSTANCE_STATUS_CODE.STARTING
-              ? 'pink'
-              : ''
+            ? 'pink'
+            : ''
         "
       >
         <span>
@@ -134,7 +134,7 @@ const toInstanceTerminal = async () => {
           <ExclamationCircleOutlined v-else />
           {{
             t(String(INSTANCE_STATUS[props.targetInstanceInfo?.status ?? -1])) ||
-              t("TXT_CODE_c8333afa")
+            t("TXT_CODE_c8333afa")
           }}
         </span>
       </a-tag>


### PR DESCRIPTION
xterm.js 默认的 UnicodeV6 实现对于 emoji 等字符在渲染时会有占 2 格显示却只按 1 格计算光标位置的问题，导致文字重叠错位。通过使用 `@xterm/addon-unicode11` 使 emoji 等字符能正确显示。

同时修改了终端 Ctrl+C 的复制逻辑，原实现会静默失败且在非安全上下文下不清除选区。改为复用已有的 `toCopy` 工具函数，因此也有了成功与否的提示。

另外修复了全局节点模式下实例列表的名称溢出问题，之前在节点名称超出省略时会占用两行的空间。

改动：
- 添加和使用 `@xterm/addon-unicode11` 依赖
- Ctrl+C 复制逻辑改为调用 `toCopy`
- 全局节点模式实例名称最大宽度从 200px 调整为 190px

改动前：

<img width="1365" height="174" alt="image" src="https://github.com/user-attachments/assets/cd6ec8d3-0be9-4340-bc42-87ad11c0a341" />

<img width="434" height="62" alt="image" src="https://github.com/user-attachments/assets/70643804-fc54-4786-92e3-fd86700ad614" />

改动后：

<img width="1362" height="205" alt="image" src="https://github.com/user-attachments/assets/58e631b2-7d0a-4377-93d5-7e9790b8eeea" />

<img width="463" height="57" alt="image" src="https://github.com/user-attachments/assets/31307e02-75bb-4c41-8a3f-2f1d6f0fc2b2" />
