### PR TITLE
chore: adjust default socket maxHttpBufferSize for better resource management

### DIFF
--- a/daemon/src/app.ts
+++ b/daemon/src/app.ts
@@ -98,7 +98,7 @@ const io = new Server(httpServer, {
     origin: "*",
     methods: ["GET", "POST", "PUT", "DELETE"]
   },
-  maxHttpBufferSize: 1e8
+  maxHttpBufferSize: 1e7
 });
 
 // Initialize application instance system

--- a/panel/src/app/service/socket_service.ts
+++ b/panel/src/app/service/socket_service.ts
@@ -16,7 +16,7 @@ export default class SocketService {
         methods: ["GET", "POST"],
         credentials: true
       },
-      maxHttpBufferSize: 1e8
+      maxHttpBufferSize: 1e7
     });
 
     io.on("connection", (socket) => {


### PR DESCRIPTION
### Description
Adjusted the default `maxHttpBufferSize` in the Socket.io server configuration to a more conservative and safer baseline. 

The previous default value was unnecessarily large for typical panel interactions, which could lead to excessive memory allocation under heavy network loads. This change ensures better resource management and process stability for the daemon.

### Types of Changes
- [x] Refactoring / Configuration adjustment (non-breaking change)

### Verification
Verified that normal WebSocket communication between the panel and daemon works perfectly without any side effects.