### PR TITLE
Bugfix

### DIFF
--- a/daemon/src/common/compress.ts
+++ b/daemon/src/common/compress.ts
@@ -70,7 +70,7 @@ export async function decompress(
     }
   };
 
-  if (!await check7zipStatus()) {
+  if (await check7zipStatus()) {
     try {
       return await use7zip(zipPath, dest);
     } catch (error) {

--- a/daemon/src/service/docker_process_service.ts
+++ b/daemon/src/service/docker_process_service.ts
@@ -16,6 +16,7 @@ import { AsyncTask } from "./async_task_service";
 import logger from "./log";
 import { NetworkLimitService } from "./network_limit_service";
 import InstanceSubsystem from "./system_instance";
+import { getLinuxSystemId } from "../tools/system_user";
 
 type PublicPortArray = {
   [key: string]: {
@@ -396,6 +397,19 @@ export class SetupDockerContainer extends AsyncTask {
       }
     }
 
+    // Convert runAs username to UID:GID format for Docker
+    let dockerUser: string | undefined = undefined;
+    if (instance.config.runAs && instance.config.runAs.trim()) {
+      try {
+        const { uid, gid } = await getLinuxSystemId(instance.config.runAs);
+        dockerUser = `${uid}:${gid}`;
+        logger.info(`Docker User: ${dockerUser} (converted from ${instance.config.runAs})`);
+      } catch (error: any) {
+        logger.warn(`Failed to get UID/GID for user ${instance.config.runAs}: ${error.message}`);
+        dockerUser = instance.config.runAs;
+      }
+    }
+
     this.container = await docker.createContainer({
       Entrypoint: entrypoint,
       Cmd: startCmd,
@@ -411,7 +425,7 @@ export class SetupDockerContainer extends AsyncTask {
       StdinOnce: false,
       ExposedPorts: exposedPorts,
       Env: dockerConfig?.env || [],
-      User: instance.config.runAs || undefined,
+      User: dockerUser,
       Labels: {
         ...dockerConfig.labels
           ?.map((label) => {

--- a/daemon/src/service/docker_process_service.ts
+++ b/daemon/src/service/docker_process_service.ts
@@ -397,16 +397,18 @@ export class SetupDockerContainer extends AsyncTask {
       }
     }
 
-    // Convert runAs username to UID:GID format for Docker
-    let dockerUser: string | undefined = undefined;
-    if (instance.config.runAs && instance.config.runAs.trim()) {
+    // Convert Linux host username to UID:GID format for Docker.
+    const runAs = instance.config.runAs?.trim();
+    let dockerUser: string | undefined = runAs || undefined;
+    const shouldResolveHostUser =
+      runAs && process.platform === "linux" && !runAs.includes(":") && !/^\d+$/.test(runAs);
+    if (shouldResolveHostUser) {
       try {
-        const { uid, gid } = await getLinuxSystemId(instance.config.runAs);
+        const { uid, gid } = await getLinuxSystemId(runAs);
         dockerUser = `${uid}:${gid}`;
-        logger.info(`Docker User: ${dockerUser} (converted from ${instance.config.runAs})`);
+        logger.info(`Docker User: ${dockerUser} (converted from ${runAs})`);
       } catch (error: any) {
-        logger.warn(`Failed to get UID/GID for user ${instance.config.runAs}: ${error.message}`);
-        dockerUser = instance.config.runAs;
+        logger.warn(`Failed to get UID/GID for user ${runAs}: ${error.message}`);
       }
     }
 

--- a/daemon/src/service/network_limit_service.ts
+++ b/daemon/src/service/network_limit_service.ts
@@ -1,4 +1,4 @@
-import { exec } from "child_process";
+import { exec, execFile } from "child_process";
 import Dockerode from "dockerode";
 import fs from "fs";
 import { promisify } from "util";
@@ -6,6 +6,73 @@ import { DefaultDocker } from "./docker_service";
 import logger from "./log";
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
+const COMMAND_TIMEOUT_MS = 10000;
+
+async function runCommand(command: string): Promise<{ stdout: string; stderr: string }> {
+  return execAsync(command, { timeout: COMMAND_TIMEOUT_MS });
+}
+
+async function runFile(
+  command: string,
+  args: string[] = []
+): Promise<{ stdout: string; stderr: string }> {
+  const { stdout, stderr } = await execFileAsync(command, args, { timeout: COMMAND_TIMEOUT_MS });
+  return { stdout: String(stdout || ""), stderr: String(stderr || "") };
+}
+
+function getErrorText(err: any): string {
+  return `${err?.stderr || ""}\n${err?.stdout || ""}\n${err?.message || ""}`;
+}
+
+function isPermissionError(err: any): boolean {
+  const errorText = getErrorText(err);
+  return (
+    (err.code === 1 || err.code === 2) &&
+    (errorText.includes("Operation not permitted") ||
+      errorText.includes("Permission denied") ||
+      errorText.includes("RTNETLINK answers: Operation not permitted"))
+  );
+}
+
+function formatCommand(command: string, args: string[] = []): string {
+  return [command, ...args].join(" ");
+}
+
+async function execWithSudo(
+  command: string,
+  args: string[] = []
+): Promise<{ stdout: string; stderr: string }> {
+  try {
+    return await runFile(command, args);
+  } catch (err: any) {
+    if (!isPermissionError(err)) {
+      throw err;
+    }
+
+    logger.info(
+      `Command requires elevated privileges, retrying with sudo: ${formatCommand(command, args)}`
+    );
+    return await runFile("sudo", ["-n", command, ...args]);
+  }
+}
+
+async function readFileWithSudo(path: string): Promise<string | null> {
+  try {
+    return fs.readFileSync(path, "utf8").trim();
+  } catch (err: any) {
+    if (err.code !== "EACCES" && err.code !== "EPERM") {
+      return null;
+    }
+    logger.info(`File requires elevated privileges, retrying with sudo: ${path}`);
+    try {
+      const { stdout } = await runFile("sudo", ["-n", "cat", path]);
+      return (stdout || "").trim();
+    } catch {
+      return null;
+    }
+  }
+}
 
 export interface BandwidthLimit {
   uploadLimit?: number;
@@ -25,7 +92,7 @@ const TBF_LATENCY = "400ms";
  * Commands required for bandwidth limit. Only tc and ip are strictly required.
  * modprobe is not required: it is used only to load the ifb kernel module (upload limit).
  * Many kernels have ifb built-in or loaded at boot; modprobe comes from the kmod package
- * and may be missing on minimal/container hosts. We run "modprobe ifb 2>/dev/null || true"
+ * and may be missing on minimal/container hosts. We try "modprobe ifb" best-effort
  * and rely on "ip link add type ifb" failing with a clear error if ifb is unavailable.
  */
 const REQUIRED_COMMANDS = ["tc", "ip"] as const;
@@ -174,31 +241,41 @@ export class NetworkLimitService {
     const tryPaths = ["eth0"];
     try {
       const netDir = `/proc/${pid}/root/sys/class/net`;
-      if (fs.existsSync(netDir)) {
+      try {
         const ifaces = fs.readdirSync(netDir).filter((n) => n !== "lo");
         ifaces.forEach((n) => {
           if (!tryPaths.includes(n)) tryPaths.push(n);
         });
+      } catch (err: any) {
+        if (err.code !== "EACCES" && err.code !== "EPERM") throw err;
+        try {
+          const { stdout } = await execWithSudo("ls", ["-1", netDir]);
+          if (stdout) {
+            const ifaces = stdout.trim().split("\n").filter((n) => n !== "lo");
+            ifaces.forEach((n) => {
+              if (!tryPaths.includes(n)) tryPaths.push(n);
+            });
+          }
+        } catch {
+          // ignore
+        }
       }
     } catch {
       // ignore
     }
     for (const iface of tryPaths) {
       const procPath = `/proc/${pid}/root/sys/class/net/${iface}/iflink`;
-      try {
-        const value = fs.readFileSync(procPath, "utf8").trim();
-        if (value) return value;
-      } catch {
-        // continue
-      }
+      const value = await readFileWithSudo(procPath);
+      if (value) return value;
     }
     for (const iface of tryPaths) {
       try {
-        const { stdout } = await execAsync(
-          `docker exec ${this.escapeShell(containerId)} cat /sys/class/net/${this.escapeShell(
-            iface
-          )}/iflink 2>/dev/null`
-        );
+        const { stdout } = await runFile("docker", [
+          "exec",
+          containerId,
+          "cat",
+          `/sys/class/net/${iface}/iflink`
+        ]);
         const value = (stdout || "").trim().replace(/\r/g, "");
         if (value) return value;
       } catch {
@@ -214,7 +291,7 @@ export class NetworkLimitService {
   /** Find host interface name by ifindex using ip -o link (avoids shell escaping). */
   private async findVethByIfindex(ifindex: string): Promise<string | null> {
     try {
-      const { stdout } = await execAsync("ip -o link show");
+      const { stdout } = await execWithSudo("ip", ["-o", "link", "show"]);
       const lines = (stdout || "").trim().split("\n");
       for (const line of lines) {
         const match = line.match(/^\s*(\d+)\s*:\s*(\S+)\s*:/);
@@ -224,16 +301,7 @@ export class NetworkLimitService {
         }
       }
     } catch {
-      // fallback: grep + sed on host
-      try {
-        const { stdout } = await execAsync(
-          `sh -c 'F=$(grep -l "^${ifindex}$" /sys/class/net/*/ifindex 2>/dev/null | head -1) && [ -n "$F" ] && basename $(dirname "$F")'`
-        );
-        const veth = (stdout || "").trim();
-        return veth || null;
-      } catch {
-        // ignore
-      }
+      return this.findVethByIfindexFromSysfs(ifindex);
     }
     return null;
   }
@@ -241,41 +309,83 @@ export class NetworkLimitService {
   /** Apply egress TBF on veth (limits download: host -> container). */
   private async applyEgressLimit(veth: string, rateKbit: number): Promise<void> {
     const rate = `${rateKbit}kbit`;
-    await execAsync(
-      `tc qdisc replace dev ${this.escapeShell(
-        veth
-      )} root tbf rate ${rate} burst ${TBF_BURST} latency ${TBF_LATENCY}`
-    );
+    await execWithSudo("tc", [
+      "qdisc",
+      "replace",
+      "dev",
+      veth,
+      "root",
+      "tbf",
+      "rate",
+      rate,
+      "burst",
+      TBF_BURST,
+      "latency",
+      TBF_LATENCY
+    ]);
   }
 
   /** Apply ingress limit via IFB (limits upload: container -> host). */
   private async applyIngressLimit(veth: string, ifbName: string, rateKbit: number): Promise<void> {
     const rate = `${rateKbit}kbit`;
-    await execAsync("modprobe ifb 2>/dev/null || true");
-    await execAsync(`ip link add name ${this.escapeShell(ifbName)} type ifb 2>/dev/null || true`);
-    await execAsync(`ip link set dev ${this.escapeShell(ifbName)} up`);
-    await execAsync(`tc qdisc replace dev ${this.escapeShell(veth)} ingress`);
-    await execAsync(
-      `tc filter add dev ${this.escapeShell(
-        veth
-      )} parent ffff: protocol all u32 match u32 0 0 action mirred egress redirect dev ${this.escapeShell(
-        ifbName
-      )}`
-    );
-    await execAsync(
-      `tc qdisc replace dev ${this.escapeShell(
-        ifbName
-      )} root tbf rate ${rate} burst ${TBF_BURST} latency ${TBF_LATENCY}`
-    );
+    await execWithSudo("modprobe", ["ifb"]).catch(() => {});
+    await execWithSudo("ip", ["link", "add", "name", ifbName, "type", "ifb"]).catch((err) => {
+      if (!this.isAlreadyExistsError(err)) throw err;
+    });
+    await execWithSudo("ip", ["link", "set", "dev", ifbName, "up"]);
+    await execWithSudo("tc", ["qdisc", "replace", "dev", veth, "ingress"]);
+    await execWithSudo("tc", [
+      "filter",
+      "add",
+      "dev",
+      veth,
+      "parent",
+      "ffff:",
+      "protocol",
+      "all",
+      "u32",
+      "match",
+      "u32",
+      "0",
+      "0",
+      "action",
+      "mirred",
+      "egress",
+      "redirect",
+      "dev",
+      ifbName
+    ]);
+    await execWithSudo("tc", [
+      "qdisc",
+      "replace",
+      "dev",
+      ifbName,
+      "root",
+      "tbf",
+      "rate",
+      rate,
+      "burst",
+      TBF_BURST,
+      "latency",
+      TBF_LATENCY
+    ]);
   }
 
   /** Remove tc qdiscs and IFB for the given veth (and optional ifb). */
   private async clearLimitForVeth(veth: string, ifbName?: string): Promise<void> {
-    await execAsync(`tc qdisc del dev ${this.escapeShell(veth)} root 2>/dev/null || true`);
-    await execAsync(`tc qdisc del dev ${this.escapeShell(veth)} ingress 2>/dev/null || true`);
+    await execWithSudo("tc", ["qdisc", "del", "dev", veth, "root"]).catch((err) => {
+      if (!this.isIgnorableDeleteError(err)) throw err;
+    });
+    await execWithSudo("tc", ["qdisc", "del", "dev", veth, "ingress"]).catch((err) => {
+      if (!this.isIgnorableDeleteError(err)) throw err;
+    });
     if (ifbName) {
-      await execAsync(`tc qdisc del dev ${this.escapeShell(ifbName)} root 2>/dev/null || true`);
-      await execAsync(`ip link del ${this.escapeShell(ifbName)} 2>/dev/null || true`);
+      await execWithSudo("tc", ["qdisc", "del", "dev", ifbName, "root"]).catch((err) => {
+        if (!this.isIgnorableDeleteError(err)) throw err;
+      });
+      await execWithSudo("ip", ["link", "del", ifbName]).catch((err) => {
+        if (!this.isIgnorableDeleteError(err)) throw err;
+      });
     }
   }
 
@@ -284,7 +394,7 @@ export class NetworkLimitService {
     const missing: string[] = [];
     for (const cmd of REQUIRED_COMMANDS) {
       try {
-        await execAsync(`command -v ${this.escapeShell(cmd)}`);
+        await runCommand(`command -v ${cmd}`);
       } catch {
         missing.push(cmd);
       }
@@ -292,8 +402,36 @@ export class NetworkLimitService {
     return missing;
   }
 
-  private escapeShell(s: string): string {
-    return `'${String(s).replace(/'/g, "'\"'\"'")}'`;
+  private findVethByIfindexFromSysfs(ifindex: string): string | null {
+    try {
+      const names = fs.readdirSync("/sys/class/net");
+      for (const name of names) {
+        try {
+          const value = fs.readFileSync(`/sys/class/net/${name}/ifindex`, "utf8").trim();
+          if (value === ifindex) return name;
+        } catch {
+          // continue
+        }
+      }
+    } catch {
+      // ignore
+    }
+    return null;
+  }
+
+  private isAlreadyExistsError(err: any): boolean {
+    const text = getErrorText(err);
+    return text.includes("File exists") || text.includes("already exists");
+  }
+
+  private isIgnorableDeleteError(err: any): boolean {
+    const text = getErrorText(err);
+    return (
+      text.includes("No such file or directory") ||
+      text.includes("Cannot find device") ||
+      text.includes("Invalid argument") ||
+      text.includes("No such process")
+    );
   }
 
   private async inspectContainer(containerId: string) {

--- a/daemon/src/service/network_limit_service.ts
+++ b/daemon/src/service/network_limit_service.ts
@@ -28,10 +28,11 @@ function getErrorText(err: any): string {
 function isPermissionError(err: any): boolean {
   const errorText = getErrorText(err);
   return (
-    (err.code === 1 || err.code === 2) &&
-    (errorText.includes("Operation not permitted") ||
-      errorText.includes("Permission denied") ||
-      errorText.includes("RTNETLINK answers: Operation not permitted"))
+    err?.code === "EACCES" ||
+    err?.code === "EPERM" ||
+    errorText.includes("Operation not permitted") ||
+    errorText.includes("Permission denied") ||
+    errorText.includes("RTNETLINK answers: Operation not permitted")
   );
 }
 
@@ -59,7 +60,7 @@ async function execWithSudo(
 
 async function readFileWithSudo(path: string): Promise<string | null> {
   try {
-    return fs.readFileSync(path, "utf8").trim();
+    return (await fs.promises.readFile(path, "utf8")).trim();
   } catch (err: any) {
     if (err.code !== "EACCES" && err.code !== "EPERM") {
       return null;
@@ -278,7 +279,13 @@ export class NetworkLimitService {
         ]);
         const value = (stdout || "").trim().replace(/\r/g, "");
         if (value) return value;
-      } catch {
+      } catch (err: any) {
+        if (err?.code === "ENOENT") {
+          logger.warn(
+            `Could not read iflink for container ${containerId}: docker binary is unavailable`
+          );
+          break;
+        }
         // continue
       }
     }
@@ -303,7 +310,7 @@ export class NetworkLimitService {
     } catch {
       return this.findVethByIfindexFromSysfs(ifindex);
     }
-    return null;
+    return this.findVethByIfindexFromSysfs(ifindex);
   }
 
   /** Apply egress TBF on veth (limits download: host -> container). */
@@ -328,7 +335,13 @@ export class NetworkLimitService {
   /** Apply ingress limit via IFB (limits upload: container -> host). */
   private async applyIngressLimit(veth: string, ifbName: string, rateKbit: number): Promise<void> {
     const rate = `${rateKbit}kbit`;
-    await execWithSudo("modprobe", ["ifb"]).catch(() => {});
+    await execWithSudo("modprobe", ["ifb"]).catch((err) => {
+      const errorText = getErrorText(err).trim();
+      logger.info(
+        `Best-effort modprobe ifb failed before ingress setup; continuing. ` +
+          `veth=${veth}, ifb=${ifbName}, error=${errorText}`
+      );
+    });
     await execWithSudo("ip", ["link", "add", "name", ifbName, "type", "ifb"]).catch((err) => {
       if (!this.isAlreadyExistsError(err)) throw err;
     });


### PR DESCRIPTION
## Summary

完善 Docker 默认用户相关逻辑，让非 root 启动 Daemon 的用户也能在具备 sudo 权限时使用 Docker 网络限速，修复 7zip 解压判断问题。

## Changes

- 优化 Docker 网络限速命令执行
  - 将 `tc`、`ip`、`modprobe` 等命令改为参数化 `execFile` 调用
  - 当 Daemon 不是 root 启动且网络限速命令遇到权限错误时，自动使用 `sudo -n` 非交互重试
  - 允许具备免密 sudo 权限的非 root 用户正常应用 Docker 网络限速
  - 在读取容器网络接口信息时，支持权限不足时通过 sudo 读取 `/proc/.../iflink`

- 修复 Docker 容器 `runAs` 用户处理
  - 启动 Docker 容器前，将宿主机系统用户名转换为 `UID:GID`
  - 转换失败时回退使用原始 `runAs` 字符串，保留容器内用户名或数字 UID 等原有用法

- 修复网页端解压 `.7z` 等格式时的 7zip 判断逻辑
  - 7zip 可用时优先使用 `use7zip()`
  - 7zip 不可用或执行失败时再回退到 ZIP 解压逻辑
  - 避免 7zip 已安装却错误提示缺少 7zip 依赖支持