### PR TITLE
fix: support nested path creation in mkdir and newFile

### DIFF
--- a/daemon/src/routers/file_router.ts
+++ b/daemon/src/routers/file_router.ts
@@ -150,11 +150,11 @@ routerApp.on("file/status", async (ctx, data) => {
 });
 
 // Create a new file
-routerApp.on("file/touch", (ctx, data) => {
+routerApp.on("file/touch", async (ctx, data) => {
   try {
     const target = data.target;
     const fileManager = getFileManager(data.instanceUuid);
-    fileManager.newFile(target);
+    await fileManager.newFile(target);
     protocol.response(ctx, true);
   } catch (error: any) {
     protocol.responseError(ctx, error);
@@ -162,11 +162,11 @@ routerApp.on("file/touch", (ctx, data) => {
 });
 
 // Create a directory
-routerApp.on("file/mkdir", (ctx, data) => {
+routerApp.on("file/mkdir", async (ctx, data) => {
   try {
     const target = data.target;
     const fileManager = getFileManager(data.instanceUuid);
-    fileManager.mkdir(target);
+    await fileManager.mkdir(target);
     protocol.response(ctx, true);
   } catch (error: any) {
     protocol.responseError(ctx, error);

--- a/daemon/src/service/system_file.ts
+++ b/daemon/src/service/system_file.ts
@@ -24,7 +24,10 @@ interface IFile {
 export default class FileManager {
   public cwd: string = ".";
 
-  constructor(public topPath: string = "", public fileCode?: string) {
+  constructor(
+    public topPath: string = "",
+    public fileCode?: string
+  ) {
     if (!path.isAbsolute(topPath)) {
       this.topPath = path.normalize(path.join(process.cwd(), topPath));
     } else {
@@ -207,8 +210,9 @@ export default class FileManager {
     // if (!FileManager.checkFileName(fileName)) throw new Error(ERROR_MSG_01);
     if (!this.checkPath(fileName)) throw new Error(ERROR_MSG_01);
     const target = this.toAbsolutePath(fileName);
-    fs.ensureDirSync(path.dirname(target));
-    fs.createFile(target);
+    const parentDir = path.resolve(path.dirname(target));
+    if (parentDir !== path.parse(parentDir).root) await fs.mkdir(parentDir, { recursive: true });
+    return await fs.createFile(target);
   }
 
   async copy(target1: string, target2: string) {

--- a/daemon/src/service/system_file.ts
+++ b/daemon/src/service/system_file.ts
@@ -207,6 +207,7 @@ export default class FileManager {
     // if (!FileManager.checkFileName(fileName)) throw new Error(ERROR_MSG_01);
     if (!this.checkPath(fileName)) throw new Error(ERROR_MSG_01);
     const target = this.toAbsolutePath(fileName);
+    fs.ensureDirSync(path.dirname(target));
     fs.createFile(target);
   }
 
@@ -220,7 +221,7 @@ export default class FileManager {
   mkdir(target: string) {
     if (!this.checkPath(target)) throw new Error(ERROR_MSG_01);
     const targetPath = this.toAbsolutePath(target);
-    return fs.mkdirSync(targetPath);
+    return fs.mkdirSync(targetPath, { recursive: true });
   }
 
   async delete(target: string): Promise<boolean> {


### PR DESCRIPTION
fix #2175 

mkdir 添加 { recursive: true } 自动创建父目录，
newFile 创建前用 mkdirSync({ recursive: true }) 确保父目录存在，
支持 a/b 和 a/b.txt 一次性创建嵌套结构。

同时修复 mkdir 和 newFile 缺少 await 导致 FileManager 处理时报错但api依然返回200的问题。
