### PR TITLE
fix: API request handling improvements

### DIFF
--- a/panel/src/app/middleware/validator.ts
+++ b/panel/src/app/middleware/validator.ts
@@ -74,7 +74,8 @@ export default function (parameter: IParam) {
     try {
       parameter["params"] && check(ctx.params, parameter["params"]);
       parameter["query"] && check(ctx.query, parameter["query"]);
-      parameter["body"] && check(ctx.request.body, parameter["body"]);
+      if (parameter["body"] && Object.keys(parameter["body"]).length > 0)
+        check(ctx.request.body, parameter["body"]);
       return await next();
     } catch (err: any) {
       ctx.status = 400;

--- a/panel/src/app/routers/instance_operate_router.ts
+++ b/panel/src/app/routers/instance_operate_router.ts
@@ -7,7 +7,7 @@ import permission from "../middleware/permission";
 import validator from "../middleware/validator";
 import { checkInstanceAdvancedParams, getAppMarketList } from "../service/instance_service";
 import { operationLogger } from "../service/operation_logger";
-import { getUserUuid } from "../service/passport_service";
+import { getUserPermission, getUserUuid } from "../service/passport_service";
 import { timeUuid } from "../service/password";
 import { isHaveInstanceByUuid, isTopPermissionByUuid } from "../service/permission_service";
 import RemoteRequest, { RemoteRequestTimeoutError } from "../service/remote_command";
@@ -506,7 +506,7 @@ router.post(
         instanceUuid,
         taskName,
         parameter,
-        role: ctx.session?.["role"] as ROLE // Permission check is performed in the daemon
+        role: getUserPermission(ctx) // Permission check is performed in the daemon
       });
       ctx.body = result;
     } catch (err) {


### PR DESCRIPTION
### validator: 空 body schema 跳过校验

当路由声明的 body 校验规则为空对象（即不需要任何 body 参数）时，跳过校验。避免如 `Content-Type: application/json` + 无 body 的 POST 请求被误拦。
(api文档里有不少接口就是 POST 但 body 参数是空的，比如asynchronous，然后要求请求头是 application/json )

### asynchronous handler: API Key 认证时正确传递 role

`ctx.session` 在 API Key 认证下不包含 `role` 字段，导致 daemon 收到 `role: undefined` 后抛出 "Invalid role"。
改用 `getUserPermission(ctx)` 获取权限，同时覆盖 session 和 API Key 两种认证方式。
