### PR TITLE
fix: select-all button not working in instance list

### DIFF
--- a/frontend/src/widgets/InstanceList.vue
+++ b/frontend/src/widgets/InstanceList.vue
@@ -370,20 +370,20 @@ const handleSelectInstance = (item: InstanceMoreDetail) => {
 };
 
 const selectAllInstances = () => {
-  let allInstancesCount = 0;
-  for (const node of tableTreeData.value) {
-    if (!node.children) continue;
-    allInstancesCount += node.children.length;
-  }
-
   selectedInstance.value = [];
-  if (allInstancesCount === selectedInstance.value?.length) return;
 
-  for (const node of tableTreeData.value) {
-    if (!node.children) continue;
-    for (const child of node.children) {
-      if (findInstance(child.inst)) continue;
-      selectedInstance.value.push(child.inst);
+  if (isGlobalDaemonMode.value) {
+    for (const node of tableTreeData.value) {
+      if (!node.children) continue;
+      for (const child of node.children) {
+        if (findInstance(child.inst)) continue;
+        selectedInstance.value.push(child.inst);
+      }
+    }
+  } else {
+    for (const item of instancesMoreInfo.value) {
+      if (findInstance(item)) continue;
+      selectedInstance.value.push(item);
     }
   }
 };


### PR DESCRIPTION
fix #2182
修复实例列表全选无法正常工作的问题
tableTreeData只在节点总览中被填充
现在在非节点总览下直接从instancesMoreInfo获取
（不过目前节点总览也没法批量操作但说不定之后要做呢）
