### PR TITLE
feat: add Windrose and Windrose+ management

### DIFF
--- a/frontend/src/assets/scripts/StartWindrosePlusManaged.ps1
+++ b/frontend/src/assets/scripts/StartWindrosePlusManaged.ps1
@@ -1,0 +1,19 @@
+$ErrorActionPreference = "Stop"
+$gameDir = $PSScriptRoot
+$dashboardScript = Join-Path $gameDir "windrose_plus\server\windrose_plus_server.ps1"
+$dashboard = Start-Process powershell.exe -ArgumentList @(
+    "-NoProfile",
+    "-ExecutionPolicy", "Bypass",
+    "-File", "`"$dashboardScript`"",
+    "-GameDir", "`"$gameDir`"",
+    "-Port", "8780"
+) -PassThru -NoNewWindow
+try {
+    & (Join-Path $gameDir "StartWindrosePlusServer.bat") @args
+    exit $LASTEXITCODE
+}
+finally {
+    if (!$dashboard.HasExited) {
+        Stop-Process -Id $dashboard.Id -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/frontend/src/config/index.ts
+++ b/frontend/src/config/index.ts
@@ -13,6 +13,7 @@ import Schedule from "@/widgets/instance/Schedule.vue";
 import InstanceServerConfigFile from "@/widgets/instance/ServerConfigFile.vue";
 import InstanceServerConfigOverview from "@/widgets/instance/ServerConfigOverview.vue";
 import InstanceShortcut from "@/widgets/instance/Shortcut.vue";
+import WindrosePlusPanel from "@/widgets/instance/WindrosePlusPanel.vue";
 import Terminal from "@/widgets/instance/Terminal.vue";
 import InstanceChart from "@/widgets/InstanceChart.vue";
 import InstanceList from "@/widgets/InstanceList.vue";
@@ -74,6 +75,7 @@ export const LAYOUT_CARD_TYPES: { [key: string]: any } = {
   InstanceServerConfigFile,
   InstanceFileManager,
   InstanceModManager,
+  WindrosePlusPanel,
   UserAccessSettings,
   ImageBox,
   QuickStartFlow,

--- a/frontend/src/config/instanceConfigMap.ts
+++ b/frontend/src/config/instanceConfigMap.ts
@@ -6,6 +6,58 @@ export const configData: {
     config: Record<string, any>;
   };
 } = {
+  "windrose/ServerDescription.json": {
+    desc: "Windrose server connection and identity settings. Stop the server before saving.",
+    config: {
+      ServerDescription_Persistent: {
+        InviteCode: {
+          description: "Case-sensitive invite code (at least 6 alphanumeric characters).",
+          control: "text"
+        },
+        UseDirectConnection: {
+          description: "Allow players to connect directly by IP and port instead of invite code.",
+          control: "boolean"
+        },
+        DirectConnectionServerPort: {
+          description: "Direct-connection port.",
+          control: "number",
+          min: 1,
+          max: 65535,
+          step: 1
+        },
+        DirectConnectionProxyAddress: {
+          description: "Address used by the direct-connection proxy.",
+          control: "text"
+        },
+        UserSelectedRegion: {
+          description: "Connection-service region.",
+          control: "select",
+          options: ["SEA", "CIS", "EU"].map((value) => ({ label: value, value }))
+        },
+        IsPasswordProtected: {
+          description: "Require a password to join.",
+          control: "boolean"
+        },
+        Password: { description: "Server join password.", control: "password" },
+        ServerName: { description: "Server name shown to players.", control: "text" },
+        MaxPlayerCount: {
+          description: "Maximum simultaneous players.",
+          control: "number",
+          min: 1,
+          max: 10,
+          step: 1
+        },
+        P2pProxyAddress: {
+          description: "Internal P2P proxy address.",
+          control: "text"
+        }
+      }
+    }
+  },
+  "windrose/windrose_plus.json": {
+    desc: "Windrose+ live map, RCON, multiplier, and feature settings. Unknown options remain editable.",
+    config: {}
+  },
   "common/server.properties": {
     desc: t("TXT_CODE_c3022e22"),
     config: {

--- a/frontend/src/config/router.ts
+++ b/frontend/src/config/router.ts
@@ -140,6 +140,14 @@ const originRouterConfig: RouterConfig[] = [
             }
           },
           {
+            path: `/instances/terminal/windrosePlus`,
+            name: "Windrose+ Web Panel",
+            component: LayoutContainer,
+            meta: {
+              permission: ROLE.USER
+            }
+          },
+          {
             path: `/instances/terminal/serverConfig`,
             name: t("TXT_CODE_d07742fe"),
             component: LayoutContainer,

--- a/frontend/src/hooks/useInstance.ts
+++ b/frontend/src/hooks/useInstance.ts
@@ -30,11 +30,13 @@ export const TYPE_MINECRAFT_BDS = "minecraft/bedrock/bds";
 export const TYPE_MINECRAFT_NUKKIT = "minecraft/bedrock/nukkit";
 export const TYPE_HYTALE = "hytale";
 export const TYPE_STEAM_SERVER_UNIVERSAL = "steam/universal";
+export const TYPE_WINDROSE = "steam/windrose";
 export const TYPE_TERRARIA = "steam/terraria";
 
 export const INSTANCE_TYPE_TRANSLATION: MapData<string> = {
   [TYPE_UNIVERSAL]: t("TXT_CODE_a92a4aa1"),
   [TYPE_STEAM_SERVER_UNIVERSAL]: t("TXT_CODE_3d7fbe30"),
+  [TYPE_WINDROSE]: "Windrose Dedicated Server",
   [TYPE_MINECRAFT_JAVA]: t("TXT_CODE_97f779b3"),
   [TYPE_MINECRAFT_BEDROCK]: t("TXT_CODE_7f1aef9f"),
   [TYPE_MINECRAFT_NUKKIT]: t("TXT_CODE_8f3e5807"),
@@ -412,6 +414,22 @@ export const INSTANCE_CONFIGS: InstanceConfigs[] = [
       TYPE_MINECRAFT_PURPUR,
       TYPE_MINECRAFT_LEAVES
     ]
+  },
+  {
+    fileName: "[Windrose] ServerDescription.json",
+    path: "R5/ServerDescription.json",
+    redirect: "windrose/ServerDescription.json",
+    type: "json",
+    info: "Configure Windrose server connection, name, password, region, and player limit.",
+    category: [TYPE_WINDROSE]
+  },
+  {
+    fileName: "[Windrose+] windrose_plus.json",
+    path: "windrose_plus.json",
+    redirect: "windrose/windrose_plus.json",
+    type: "json",
+    info: "Configure Windrose+ RCON, live map, multipliers, and feature flags.",
+    category: [TYPE_WINDROSE]
   },
   {
     fileName: "[Terraria] serverconfig.txt",

--- a/frontend/src/hooks/useWindrosePlus.ts
+++ b/frontend/src/hooks/useWindrosePlus.ts
@@ -1,0 +1,125 @@
+import managedScript from "@/assets/scripts/StartWindrosePlusManaged.ps1?raw";
+import { useInstanceInfo } from "@/hooks/useInstance";
+import {
+  restartInstance,
+  stopInstance,
+  updateInstance,
+  updateInstanceConfig
+} from "@/services/apis/instance";
+import { reportErrorMsg } from "@/tools/validator";
+import { Modal, message } from "ant-design-vue";
+import { computed } from "vue";
+
+const MANAGED_SCRIPT_BASE64 = btoa(managedScript);
+const NATIVE_START_COMMAND =
+  "powershell.exe -NoProfile -ExecutionPolicy Bypass -File StartWindrosePlusManaged.ps1";
+const VANILLA_START_COMMAND = "R5\\Binaries\\Win64\\WindroseServer-Win64-Shipping.exe -log";
+const STEAM_UPDATE_COMMAND =
+  '"{mcsm_steamcmd}" +force_install_dir "{mcsm_workspace}" +login anonymous +app_update 4129620 validate +quit';
+const INSTALL_COMMAND = `${STEAM_UPDATE_COMMAND} && powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "$ErrorActionPreference='Stop'; $ProgressPreference='SilentlyContinue'; $release=Invoke-RestMethod -Uri 'https://api.github.com/repos/humangenome/WindrosePlus/releases/latest'; $asset=$release.assets | Where-Object { $_.name -eq 'WindrosePlus.zip' } | Select-Object -First 1; if(-not $asset){ throw 'WindrosePlus.zip was not found in the latest release.' }; $zip=Join-Path $env:TEMP ('WindrosePlus-'+[guid]::NewGuid().ToString('N')+'.zip'); try { Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $zip -UseBasicParsing; $expected=([string]$asset.digest).Replace('sha256:','').ToLowerInvariant(); if($expected){ $actual=(Get-FileHash -LiteralPath $zip -Algorithm SHA256).Hash.ToLowerInvariant(); if($actual -ne $expected){ throw ('WindrosePlus.zip SHA-256 mismatch: '+$actual) } }; Expand-Archive -LiteralPath $zip -DestinationPath (Get-Location).Path -Force; & (Join-Path (Get-Location).Path 'install.ps1') -GameDir (Get-Location).Path; if($LASTEXITCODE -ne 0){ throw ('Windrose+ installer exited with code '+$LASTEXITCODE) }; $managed=[Convert]::FromBase64String('${MANAGED_SCRIPT_BASE64}'); [IO.File]::WriteAllBytes((Join-Path (Get-Location).Path 'StartWindrosePlusManaged.ps1'),$managed) } finally { Remove-Item -LiteralPath $zip -Force -ErrorAction SilentlyContinue }"`;
+const UNINSTALL_COMMAND = `${STEAM_UPDATE_COMMAND} && powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "$ErrorActionPreference='Stop'; $game=(Get-Location).Path; $win64=Join-Path $game 'R5\\Binaries\\Win64'; $proxy=Join-Path $win64 'dwmapi.dll'; $disabled=Join-Path $win64 'dwmapi.windroseplus.disabled'; if(Test-Path -LiteralPath $proxy){ Move-Item -LiteralPath $proxy -Destination $disabled -Force }; @('WindrosePlus_Multipliers_P.pak','WindrosePlus_CurveTables_P.pak') | ForEach-Object { Remove-Item -LiteralPath (Join-Path $game ('R5\\Content\\Paks\\'+$_)) -Force -ErrorAction SilentlyContinue }; Remove-Item -LiteralPath (Join-Path $game 'windrose_plus_data\\.windroseplus_build.hash') -Force -ErrorAction SilentlyContinue; Remove-Item -LiteralPath (Join-Path $game 'StartWindrosePlusManaged.ps1') -Force -ErrorAction SilentlyContinue; Write-Host 'Windrose+ disabled. Configuration, data, and mods were preserved.'"`;
+
+export function useWindrosePlus(instanceId: string, daemonId: string) {
+  const { instanceInfo, isRunning, execute: refreshInstance } = useInstanceInfo({
+    instanceId,
+    daemonId,
+    autoRefresh: true
+  });
+  const isDocker = computed(() => instanceInfo.value?.config?.processType === "docker");
+  const enabled = computed(() => {
+    const config = instanceInfo.value?.config;
+    if (config?.processType === "docker") {
+      return (config.docker?.env ?? []).some(
+        (value: string) => value.toLowerCase() === "windrose_plus_enabled=true"
+      );
+    }
+    const startCommand = (config?.startCommand ?? "").toLowerCase();
+    return (
+      startCommand.includes("startwindroseplusserver.bat") ||
+      startCommand.includes("startwindroseplusmanaged.ps1")
+    );
+  });
+  const { execute: saveInstance, isLoading } = updateInstanceConfig();
+
+  const setDockerEnabled = async (nextEnabled: boolean) => {
+    const config = instanceInfo.value?.config;
+    if (!config) return;
+    const env = (config.docker?.env ?? []).filter(
+      (value: string) => !value.startsWith("WINDROSE_PLUS_ENABLED=")
+    );
+    env.push(`WINDROSE_PLUS_ENABLED=${nextEnabled}`);
+    await saveInstance({
+      params: { uuid: instanceId, daemonId },
+      data: {
+        processType: config.processType,
+        startCommand: config.startCommand,
+        updateCommand: config.updateCommand,
+        docker: { env }
+      }
+    });
+    if (isRunning.value) {
+      await restartInstance().execute({ params: { uuid: instanceId, daemonId } });
+    }
+  };
+
+  const setNativeEnabled = async (nextEnabled: boolean) => {
+    if (isRunning.value) {
+      await stopInstance().execute({ params: { uuid: instanceId, daemonId } });
+    }
+    await saveInstance({
+      params: { uuid: instanceId, daemonId },
+      data: {
+        processType: "general",
+        startCommand: nextEnabled ? NATIVE_START_COMMAND : VANILLA_START_COMMAND,
+        updateCommand: nextEnabled ? INSTALL_COMMAND : UNINSTALL_COMMAND,
+        terminalOption: { haveColor: false, pty: false }
+      }
+    });
+    await updateInstance().execute({
+      params: { uuid: instanceId, daemonId, task_name: "update" },
+      data: { time: Date.now() }
+    });
+  };
+
+  const setEnabled = async (nextEnabled: boolean) => {
+    try {
+      if (isDocker.value) await setDockerEnabled(nextEnabled);
+      else await setNativeEnabled(nextEnabled);
+      await refreshInstance({
+        params: { uuid: instanceId, daemonId },
+        forceRequest: true
+      });
+      message.success(
+        isDocker.value
+          ? nextEnabled
+            ? "Windrose+ enabled. Its files will be installed during startup."
+            : "Windrose+ disabled. Existing configuration and mods were preserved."
+          : nextEnabled
+            ? "Windrose+ installation started. Follow its progress in the terminal."
+            : "Windrose+ disable task started. Configuration, data, and mods will be preserved."
+      );
+    } catch (error: any) {
+      reportErrorMsg(error?.message ?? error);
+      throw error;
+    }
+  };
+
+  const confirmToggle = () => {
+    const installing = !enabled.value;
+    Modal.confirm({
+      title: installing ? "Install Windrose+?" : "Uninstall Windrose+?",
+      content: isDocker.value
+        ? isRunning.value
+          ? "The server will restart to apply this change. Existing worlds are preserved."
+          : "This change will be applied the next time the server starts. Existing worlds are preserved."
+        : isRunning.value
+          ? "The server will stop, then Windrose+ will be installed or disabled. Existing worlds and Windrose+ user data are preserved."
+          : "Windrose+ will be installed or disabled through the instance update task. Existing worlds and Windrose+ user data are preserved.",
+      okText: installing ? "Install Windrose+" : "Uninstall Windrose+",
+      okType: installing ? "primary" : "danger",
+      onOk: () => setEnabled(installing)
+    });
+  };
+
+  return { enabled, isLoading, instanceInfo, confirmToggle };
+}

--- a/frontend/src/services/apis/instance.ts
+++ b/frontend/src/services/apis/instance.ts
@@ -147,6 +147,12 @@ export const updateInstanceConfig = useDefineApi<
       oe?: string;
       tag?: string[];
       stopCommand?: string;
+      processType?: string;
+      startCommand?: string;
+      updateCommand?: string;
+      docker?: {
+        env?: string[];
+      };
       eventTask?: {
         autoRestart: boolean;
         autoRestartMaxTimes: number;

--- a/frontend/src/widgets/instance/ManagerBtns.vue
+++ b/frontend/src/widgets/instance/ManagerBtns.vue
@@ -6,9 +6,11 @@ import {
   TYPE_MINECRAFT_JAVA,
   TYPE_MINECRAFT_MCDR,
   TYPE_STEAM_SERVER_UNIVERSAL,
+  TYPE_WINDROSE,
   useInstanceInfo
 } from "@/hooks/useInstance";
 import { useServerConfig } from "@/hooks/useServerConfig";
+import { useWindrosePlus } from "@/hooks/useWindrosePlus";
 import { t } from "@/lang/i18n";
 import { modListApi } from "@/services/apis/modManager";
 import { useAppStateStore } from "@/stores/useAppStateStore";
@@ -58,8 +60,13 @@ const { isAdmin, state } = useAppStateStore();
 
 const { getMetaOrRouteValue } = useLayoutCardTools(props.card);
 
-const instanceId = getMetaOrRouteValue("instanceId");
-const daemonId = getMetaOrRouteValue("daemonId");
+const instanceId = getMetaOrRouteValue("instanceId") ?? "";
+const daemonId = getMetaOrRouteValue("daemonId") ?? "";
+const {
+  enabled: windrosePlusEnabled,
+  isLoading: isWindrosePlusLoading,
+  confirmToggle: confirmWindrosePlusToggle
+} = useWindrosePlus(instanceId, daemonId);
 
 const { instanceInfo, execute, isGlobalTerminal } = useInstanceInfo({
   instanceId,
@@ -138,6 +145,28 @@ const btns = computed(() => {
             type: instanceInfo.value?.config.type
           }
         });
+      }
+    },
+    {
+      title: windrosePlusEnabled.value ? "Uninstall Windrose+" : "Install Windrose+",
+      icon: DashboardOutlined,
+      condition: () =>
+        !isGlobalTerminal.value && instanceInfo.value?.config.type === TYPE_WINDROSE,
+      click: confirmWindrosePlusToggle,
+      props: {
+        loading: isWindrosePlusLoading.value,
+        danger: windrosePlusEnabled.value
+      }
+    },
+    {
+      title: "Windrose+ Web Panel",
+      icon: DashboardOutlined,
+      condition: () =>
+        !isGlobalTerminal.value &&
+        instanceInfo.value?.config.type === TYPE_WINDROSE &&
+        windrosePlusEnabled.value,
+      click: () => {
+        toPage({ path: "/instances/terminal/windrosePlus" });
       }
     },
     {

--- a/frontend/src/widgets/instance/WindrosePlusPanel.vue
+++ b/frontend/src/widgets/instance/WindrosePlusPanel.vue
@@ -1,0 +1,150 @@
+<script setup lang="ts">
+import CardPanel from "@/components/CardPanel.vue";
+import { useLayoutCardTools } from "@/hooks/useCardTools";
+import { useWindrosePlus } from "@/hooks/useWindrosePlus";
+import type { LayoutCard } from "@/types";
+import { computed, ref } from "vue";
+
+const props = defineProps<{ card: LayoutCard }>();
+const { getMetaOrRouteValue } = useLayoutCardTools(props.card);
+const instanceId = getMetaOrRouteValue("instanceId") ?? "";
+const daemonId = getMetaOrRouteValue("daemonId") ?? "";
+const { instanceInfo, enabled: windrosePlusEnabled, isLoading: isSaving, confirmToggle: confirmToggleWindrosePlus } =
+  useWindrosePlus(instanceId, daemonId);
+
+const storageKey = `windrose-plus-panel:${daemonId}:${instanceId}`;
+const dashboardUrl = ref(localStorage.getItem(storageKey) ?? "");
+const activeUrl = ref(dashboardUrl.value);
+const frameKey = ref(0);
+const isHttps = window.location.protocol === "https:";
+const isDocker = computed(() => instanceInfo.value?.config?.processType === "docker");
+
+const dashboardPort = computed(() => {
+  const ports = instanceInfo.value?.config?.docker?.ports ?? [];
+  const mapping = ports.find((port: string) => port.endsWith(":8780/tcp"));
+  if (!mapping) return "";
+  return mapping.split(":").at(-2) ?? "";
+});
+
+const detectedUrl = computed(() => {
+  if (isDocker.value) {
+    if (!dashboardPort.value) return "";
+    return `http://${window.location.hostname}:${dashboardPort.value}`;
+  }
+  if (isHttps) return "";
+  return `http://${window.location.hostname}:8780`;
+});
+
+const isValidUrl = computed(() => {
+  if (!dashboardUrl.value) return false;
+  try {
+    return ["http:", "https:"].includes(new URL(dashboardUrl.value).protocol);
+  } catch {
+    return false;
+  }
+});
+
+const saveAndLoad = () => {
+  if (!isValidUrl.value) return;
+  const normalized = dashboardUrl.value.replace(/\/$/, "");
+  dashboardUrl.value = normalized;
+  activeUrl.value = normalized;
+  localStorage.setItem(storageKey, normalized);
+  frameKey.value += 1;
+};
+
+const useDetectedUrl = () => {
+  if (!detectedUrl.value) return;
+  dashboardUrl.value = detectedUrl.value;
+  saveAndLoad();
+};
+</script>
+
+<template>
+  <CardPanel style="height: 100%">
+    <template #body>
+      <a-space direction="vertical" style="width: 100%" size="middle">
+        <a-card size="small">
+          <a-space style="width: 100%; justify-content: space-between">
+            <a-space>
+              <a-badge :status="windrosePlusEnabled ? 'success' : 'default'" />
+              <strong>Windrose+ is {{ windrosePlusEnabled ? "installed" : "not installed" }}</strong>
+            </a-space>
+            <a-button
+              :type="windrosePlusEnabled ? 'default' : 'primary'"
+              :danger="windrosePlusEnabled"
+              :loading="isSaving"
+              @click="confirmToggleWindrosePlus"
+            >
+              {{ windrosePlusEnabled ? "Uninstall Windrose+" : "Install Windrose+" }}
+            </a-button>
+          </a-space>
+          <div class="mt-2 color-gray">
+            Uninstalling disables the add-on but preserves its configuration and Lua mods for later use.
+          </div>
+        </a-card>
+        <a-alert
+          v-if="!windrosePlusEnabled"
+          type="info"
+          show-icon
+          message="Install Windrose+ to use the live map and web RCON dashboard."
+        />
+        <a-alert
+          v-else-if="isDocker && !dashboardPort"
+          type="warning"
+          show-icon
+          message="Windrose+ dashboard port is not exposed"
+          description="Use the Windrose+ marketplace template or add a TCP mapping for container port 8780, then restart the instance."
+        />
+        <a-alert
+          v-else-if="!isDocker && !activeUrl"
+          type="info"
+          show-icon
+          message="Connect the native Windrose+ dashboard"
+          description="The dashboard starts with the Windows server on port 8780. For remote HTTPS access, publish that port through your reverse proxy or Cloudflare Tunnel, then enter its HTTPS URL below."
+        />
+        <a-alert
+          v-else-if="isHttps && (!activeUrl || activeUrl.startsWith('http:'))"
+          type="info"
+          show-icon
+          message="HTTPS address required for embedding"
+          description="Browsers block an HTTP dashboard inside an HTTPS MCSManager page. Put the dashboard behind an HTTPS reverse proxy or Cloudflare Tunnel, then enter that public URL below."
+        />
+
+        <a-input-group v-if="windrosePlusEnabled" compact style="display: flex">
+          <a-input
+            v-model:value="dashboardUrl"
+            placeholder="https://windrose-plus.example.com"
+            style="flex: 1"
+            @press-enter="saveAndLoad"
+          />
+          <a-button v-if="detectedUrl" @click="useDetectedUrl">Use detected local URL</a-button>
+          <a-button type="primary" :disabled="!isValidUrl" @click="saveAndLoad">
+            Save and load
+          </a-button>
+          <a-button v-if="activeUrl" :href="activeUrl" target="_blank">Open externally</a-button>
+        </a-input-group>
+
+        <a-alert
+          v-if="windrosePlusEnabled && dashboardUrl && !isValidUrl"
+          type="error"
+          show-icon
+          message="Enter a valid HTTP or HTTPS dashboard URL."
+        />
+
+        <iframe
+          v-if="windrosePlusEnabled && activeUrl"
+          :key="frameKey"
+          :src="activeUrl"
+          title="Windrose+ web panel"
+          allow="clipboard-read; clipboard-write"
+          style="width: 100%; height: 75vh; border: 0; border-radius: 6px"
+        />
+        <a-empty
+          v-else-if="windrosePlusEnabled"
+          description="Enter the Windrose+ dashboard URL to embed it here."
+        />
+      </a-space>
+    </template>
+  </CardPanel>
+</template>

--- a/panel/src/app/service/frontend_layout.ts
+++ b/panel/src/app/service/frontend_layout.ts
@@ -310,6 +310,20 @@ function getDefaultFrontendLayoutConfig(): IPageLayoutConfig[] {
       ]
     },
     {
+      page: "/instances/terminal/windrosePlus",
+      items: [
+        {
+          id: getRandomId(),
+          meta: {},
+          type: "WindrosePlusPanel",
+          title: "Windrose+ Web Panel",
+          width: 12,
+          height: LayoutCardHeight.AUTO,
+          disableDelete: true
+        }
+      ]
+    },
+    {
       page: "/instances/terminal/serverConfig",
       items: [
         {


### PR DESCRIPTION
## Summary

Adds first-class Windrose dedicated-server management and optional [Windrose+](https://github.com/HumanGenome/WindrosePlus) controls.

- register the `steam/windrose` instance type
- discover and edit `R5/ServerDescription.json` through the friendly configuration UI
- discover `windrose_plus.json` when the optional add-on is installed
- add terminal-page Install/Uninstall Windrose+ controls for Docker and native Windows instances
- download the latest official Windrose+ release asset and verify its GitHub-provided SHA-256 digest before extraction
- preserve Windrose+ configuration, runtime data, saves, and custom Lua mods when disabling it
- supervise the native Windows game server and Windrose+ dashboard together on port 8780
- add an embedded dashboard page with per-instance URL storage, HTTPS guidance, and an external-open fallback

## Native Windows behavior

Windrose itself is Windows-only. Native instances use Steam app `4129620` and start the shipping server directly. Enabling Windrose+ switches the instance to a managed PowerShell launcher that:

1. starts the Windrose+ dashboard;
2. starts Windrose through the upstream `StartWindrosePlusServer.bat` wrapper;
3. stops the dashboard when the game process exits.

Disabling the add-on restores the direct Windrose launch command, disables the UE4SS proxy, and removes only generated override PAKs/build state. User configuration, data, saves, and custom mods are retained.

## Verification

- rebased as one Windrose-only commit on current `MCSManager/MCSManager:master`
- complete production build passed:
  - common TypeScript build
  - daemon Webpack build
  - panel Webpack build
  - frontend `vue-tsc`
  - frontend Vite production build
- `git diff --check` passed
- focused ad-hoc verification confirmed the contribution contains no deployment-specific paths, addresses, domains, or unrelated game changes
- real native Windows testing confirmed:
  - Steam app `4129620` installation
  - `R5/ServerDescription.json` generation
  - world creation and `GenlandiaMulty` map load
  - Windrose+ v1.3.15 initialization through UE4SS
  - dashboard `/api/status` response on port 8780
  - iframe-compatible dashboard headers
  - dashboard cleanup when the game exits

## Companion marketplace template

The native Windows marketplace template is currently tracked in:

- https://github.com/CollinHerber/MCMS-Script/pull/6
