### PR TITLE
fix(daemon): prevent attach options leaking into Podman stdin

### DIFF
--- a/daemon/src/service/docker_process_service.ts
+++ b/daemon/src/service/docker_process_service.ts
@@ -29,6 +29,43 @@ type ExposedPorts = {
   [key: string]: {};
 };
 
+function attachDockerContainer(container: Docker.Container): Promise<NodeJS.ReadWriteStream> {
+  const query = {
+    stream: true,
+    stdout: true,
+    stderr: true,
+    stdin: true
+  };
+
+  return new Promise((resolve, reject) => {
+    container.modem.dial(
+      {
+        path: `/containers/${container.id}/attach?`,
+        method: "POST",
+        isStream: true,
+        hijack: true,
+        openStdin: true,
+        file: Buffer.alloc(0),
+        statusCodes: {
+          200: true,
+          404: "no such container",
+          500: "server error"
+        },
+        options: {
+          ...query,
+          hijack: true,
+          _query: query
+        }
+      },
+      (error: Error | null, stream: NodeJS.ReadWriteStream | null) => {
+        if (error) return reject(error);
+        if (!stream) return reject(new Error("Docker attach returned no stream"));
+        resolve(stream);
+      }
+    );
+  });
+}
+
 // Error exception at startup
 export class StartupDockerProcessError extends Error {
   constructor(msg: string) {
@@ -524,13 +561,7 @@ export class SetupDockerContainer extends AsyncTask {
     const container = this.container;
     if (!container) throw new Error("Attach Failed, Container is Null!");
     try {
-      const stream = await container.attach({
-        stream: true,
-        stdout: true,
-        stderr: true,
-        stdin: true,
-        hijack: true
-      });
+      const stream = await attachDockerContainer(container);
       stream.on("data", (text: any) => instance.print(iconv.decode(text, outputCode)));
       stream.on("error", (text: any) => instance.print(iconv.decode(text, outputCode)));
     } catch (error: any) {
@@ -571,13 +602,7 @@ export class DockerProcessAdapter extends EventEmitter implements IInstanceProce
       }
 
       this.pid = this.container.id;
-      this.stream = await this.container.attach({
-        stream: true,
-        stdout: true,
-        stderr: true,
-        stdin: true,
-        hijack: true
-      });
+      this.stream = await attachDockerContainer(this.container);
       this.stream.on("data", (data) => this.emit("data", data));
       this.stream.on("error", (data) => this.emit("data", data));
       this.wait();


### PR DESCRIPTION
## Problem

When MCSManager attaches to a container through Podman's Docker-compatible API, the attach options can leak into the container's stdin:

```
[20:14:43 INFO] [viabackwards]: Loading translations...
[20:14:43 INFO] [viabackwards]: Registering protocols...
[20:14:43 INFO] [viaversion]: Finished mapping loading, shutting down loader executor.
[20:14:43 INFO]: Listening on /[0:0:0:0:0:0:0:0]:25565
[20:14:43 WARN]: Using HAProxy and listening on /[0:0:0:0:0:0:0:0]:25565, please ensure this listener is adequately firewalled.
[20:14:43 INFO]: Done (4.49s)!
[20:14:44 WARN] [viaversion]: There is a newer plugin version available: 5.8.1, you're on: 5.7.0
[20:15:08 INFO]: [initial connection] /51.159.149.103:1001 is pinging the server with version 1.21.11
> {"stream":true,"stdout":true,"stderr":true,"stdin":true,"hijack":true}
```

The injected JSON remains in the application's input buffer and is prepended to the next console command. For example, sending `stop` using the panel's stop function may result in:

```text
{"stream":true,"stdout":true,"stderr":true,"stdin":true,"hijack":true}stop
```

The command is therefore not recognized, which can prevent normal stop or restart operations from completing and may require forced termination or manual intervention.

This behavior has also been reported upstream:

- [dockerode#742](https://github.com/apocas/dockerode/issues/742)
- [podman#19901](https://github.com/containers/podman/issues/19901)

## Cause

MCSManager currently calls dockerode's `container.attach(options)`, which passes the attach options to docker-modem without separate `_query` or `_body` values.

For a `POST` request, docker-modem then uses the same object for both the URL query and the JSON request body. The resulting request is effectively:

```http
POST /containers/<id>/attach?stream=true&stdout=true&stderr=true&stdin=true&hijack=true
Connection: Upgrade
Upgrade: tcp
Content-Type: application/json

{"stream":true,"stdout":true,"stderr":true,"stdin":true,"hijack":true}
```

The Docker Attach API expects these settings as query parameters and does not require a JSON body. Docker Engine does not expose the unsupported request body through container stdin, but Podman treats the body bytes as stdin when establishing the hijacked stream.

## Fix

Both attach paths now use a shared `attachDockerContainer()` helper that calls `container.modem.dial()` directly.

The helper separates the API and transport options:

- `_query` contains only `stream`, `stdout`, `stderr`, and `stdin`.
- `hijack: true` enables the upgraded bidirectional connection.
- `openStdin: true` keeps the returned stream writable.
- An outer `file: Buffer.alloc(0)` makes docker-modem send `Content-Length: 0` and no request body bytes.

Using `_body: {}` is not sufficient. Docker-modem discards the empty object, and `openStdin` prevents `req.end()` from being called. With no write, end, or header flush, Node.js keeps the Attach request buffered.

The empty Buffer must be supplied to the outer `modem.dial()` configuration. Arguments passed through `container.attach()` are nested inside its `options` object and therefore cannot activate docker-modem's outer `file` handling.

This preserves the existing HTTP Upgrade behavior and writable container stream while preventing attach options from leaking into stdin.

## Verification

Tested with Podman 6.0.1 and Docker Engine 29.6.1 using both an interactive TTY container and a Paper 1.21.8 server.

No attach request bytes leaked into container stdin on Podman, and existing container attach functionality continued to work normally on both engines.