### PR TITLE
fix(daemon): stop attach options leaking into container terminal

### DIFF
--- a/daemon/package-lock.json
+++ b/daemon/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcsmanager-daemon",
-  "version": "4.15.0",
+  "version": "4.16.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mcsmanager-daemon",
-      "version": "4.15.0",
+      "version": "4.16.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@koa/router": "^10.0.0",
@@ -2167,8 +2167,7 @@
     },
     "node_modules/docker-modem": {
       "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.6.tgz",
-      "integrity": "sha512-ens7BiayssQz/uAxGzH8zGXCtiV24rRWXdjNha5V4zSOcxmAZsfGVm/PPFbwQdqEkDnhG+SyR9E3zSHUbOKXBQ==",
+      "resolved": "git+https://github.com/mliem2k/docker-modem.git#3ec0b151bbcc8d5021b8303fed301b9272aba023",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.1.1",
@@ -7633,9 +7632,8 @@
       "dev": true
     },
     "docker-modem": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.6.tgz",
-      "integrity": "sha512-ens7BiayssQz/uAxGzH8zGXCtiV24rRWXdjNha5V4zSOcxmAZsfGVm/PPFbwQdqEkDnhG+SyR9E3zSHUbOKXBQ==",
+      "version": "git+https://github.com/mliem2k/docker-modem.git#3ec0b151bbcc8d5021b8303fed301b9272aba023",
+      "from": "docker-modem@git+https://github.com/mliem2k/docker-modem.git#3ec0b151bbcc8d5021b8303fed301b9272aba023",
       "requires": {
         "debug": "^4.1.1",
         "readable-stream": "^3.5.0",
@@ -7651,7 +7649,7 @@
         "@balena/dockerignore": "^1.0.2",
         "@grpc/grpc-js": "^1.11.1",
         "@grpc/proto-loader": "^0.7.13",
-        "docker-modem": "^5.0.6",
+        "docker-modem": "git+https://github.com/mliem2k/docker-modem.git#3ec0b151bbcc8d5021b8303fed301b9272aba023",
         "protobufjs": "^7.3.2",
         "tar-fs": "~2.1.2",
         "uuid": "^10.0.0"

--- a/daemon/package.json
+++ b/daemon/package.json
@@ -48,6 +48,9 @@
     "uuid": "^8.3.2",
     "yaml": "^1.10.2"
   },
+  "overrides": {
+    "docker-modem": "git+https://github.com/mliem2k/docker-modem.git#3ec0b151bbcc8d5021b8303fed301b9272aba023"
+  },
   "devDependencies": {
     "@types/archiver": "^5.3.1",
     "@types/dockerode": "^3.2.7",


### PR DESCRIPTION
## Summary

Fixes #2136 — the literal string `{"stream":true,"stdout":true,"stderr":true,"stdin":true,"hijack":true}` getting auto-typed into a container's terminal right after start.

Root cause is not in this repo — it's in `docker-modem` (a transitive dependency via `dockerode`). `Modem#buildRequest` writes its POST body to the request before an `attach()`-with-`hijack:true` connection upgrades to a raw duplex stream, so the request's own serialized options object gets delivered straight into the container's stdin. Full writeup and upstream fix: apocas/docker-modem#198.

This PR pins `daemon`'s `docker-modem` resolution (via npm `overrides`) to a fork carrying the fix, so the bug is resolved immediately without waiting on upstream review/release. Once apocas/docker-modem#198 merges and releases, this override can be dropped in favor of a normal version bump.

## Test plan

- [x] Upstream fork's regression test (real HTTP server, asserts no body bytes reach the socket before upgrade) passes.
- [x] `cd daemon && npm run build` succeeds with the overridden dependency.
- [ ] Manual: start a Docker-mode instance, confirm no garbage is auto-typed into the terminal.