### PR TITLE
fix(frontend): stop terminal backlog replay from injecting fake keystrokes

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "type-check": "vue-tsc --noEmit --skipLibCheck -p tsconfig.vitest.json --composite false",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",
     "format": "prettier --write src/",
-    "analyze": "vite build --mode analyze"
+    "analyze": "vite build --mode analyze",
+    "test": "vitest run"
   },
   "dependencies": {
     "@ant-design/icons-vue": "^6.1.0",

--- a/frontend/src/components/TerminalCore.vue
+++ b/frontend/src/components/TerminalCore.vue
@@ -38,7 +38,8 @@ const {
   execute: setUpTerminal,
   initTerminalWindow,
   sendCommand,
-  clearTerminal
+  clearTerminal,
+  writeHistoryLog
 } = props.useTerminalHook;
 
 const instanceId = props.instanceId;
@@ -94,9 +95,9 @@ events.once("detail", async () => {
 
     if (value) {
       if (state.value?.config?.terminalOption?.haveColor) {
-        term?.write(encodeConsoleColor(value));
+        await writeHistoryLog(encodeConsoleColor(value));
       } else {
-        term?.write(value);
+        await writeHistoryLog(value);
       }
     }
   } catch (error: any) {}

--- a/frontend/src/hooks/terminalHistoryReplayGate.test.ts
+++ b/frontend/src/hooks/terminalHistoryReplayGate.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { createTerminalHistoryReplayGate } from "./terminalHistoryReplayGate";
+
+describe("createTerminalHistoryReplayGate", () => {
+  it("starts not replaying", () => {
+    const gate = createTerminalHistoryReplayGate();
+    expect(gate.isReplaying()).toBe(false);
+  });
+
+  it("reports replaying once begin() is called", () => {
+    const gate = createTerminalHistoryReplayGate();
+    gate.begin();
+    expect(gate.isReplaying()).toBe(true);
+  });
+
+  it("reports not replaying once end() is called", () => {
+    const gate = createTerminalHistoryReplayGate();
+    gate.begin();
+    gate.end();
+    expect(gate.isReplaying()).toBe(false);
+  });
+
+  it("supports multiple begin/end cycles independently", () => {
+    const gate = createTerminalHistoryReplayGate();
+    gate.begin();
+    gate.end();
+    gate.begin();
+    expect(gate.isReplaying()).toBe(true);
+    gate.end();
+    expect(gate.isReplaying()).toBe(false);
+  });
+});

--- a/frontend/src/hooks/terminalHistoryReplayGate.ts
+++ b/frontend/src/hooks/terminalHistoryReplayGate.ts
@@ -1,0 +1,26 @@
+/**
+ * Tracks whether the terminal is currently replaying historical output
+ * (the backlog written into a freshly mounted terminal on reconnect)
+ * rather than processing live data.
+ *
+ * While replaying, xterm.js can synthesize escape-sequence auto-replies
+ * (e.g. a cursor-position-report response to a stale, already-unanswered
+ * `ESC[6n` query sitting in the backlog) and emit them through the same
+ * onData channel used for real keystrokes. Those synthesized replies must
+ * not be forwarded to the daemon as user input.
+ */
+export function createTerminalHistoryReplayGate() {
+  let isReplaying = false;
+
+  return {
+    isReplaying: () => isReplaying,
+    begin: () => {
+      isReplaying = true;
+    },
+    end: () => {
+      isReplaying = false;
+    }
+  };
+}
+
+export type TerminalHistoryReplayGate = ReturnType<typeof createTerminalHistoryReplayGate>;

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -352,10 +352,15 @@ export function useTerminal() {
         return;
       }
       historyReplayGate.begin();
-      term.write(text, () => {
+      try {
+        term.write(text, () => {
+          historyReplayGate.end();
+          resolve();
+        });
+      } catch (error) {
         historyReplayGate.end();
         resolve();
-      });
+      }
     });
   }
 

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -17,6 +17,7 @@ import EventEmitter from "eventemitter3";
 import type { Socket } from "socket.io-client";
 import { computed, onMounted, onUnmounted, ref, unref } from "vue";
 import { makeSocketIo } from "./useSocketIo";
+import { createTerminalHistoryReplayGate } from "./terminalHistoryReplayGate";
 
 export const TERM_COLOR = {
   TERM_RESET: "\x1B[0m",
@@ -69,6 +70,7 @@ export function useTerminal() {
   const isConnect = ref<boolean>(false);
   const socketAddress = ref("");
   let isManualDisconnect = false;
+  const historyReplayGate = createTerminalHistoryReplayGate();
 
   const isGlobalTerminal = computed(() => {
     return state.value?.config.nickname === GLOBAL_INSTANCE_NAME;
@@ -309,6 +311,13 @@ export function useTerminal() {
     }
 
     term.onData((data) => {
+      // Ignore input events fired while replaying historical backlog —
+      // these are xterm.js's own synthesized escape-sequence replies
+      // (e.g. cursor position reports), not real keystrokes.
+      if (historyReplayGate.isReplaying()) {
+        return;
+      }
+
       // If the PTY terminal is disabled, no input is sent.
       if (
         state.value?.config.terminalOption?.pty === false ||
@@ -334,6 +343,21 @@ export function useTerminal() {
 
     return term;
   };
+
+  function writeHistoryLog(text: string): Promise<void> {
+    return new Promise((resolve) => {
+      const term = terminal.value;
+      if (!term) {
+        resolve();
+        return;
+      }
+      historyReplayGate.begin();
+      term.write(text, () => {
+        historyReplayGate.end();
+        resolve();
+      });
+    });
+  }
 
   const clearTerminal = () => {
     terminal.value?.clear();
@@ -391,7 +415,8 @@ export function useTerminal() {
     execute,
     initTerminalWindow,
     sendCommand,
-    clearTerminal
+    clearTerminal,
+    writeHistoryLog
   };
 }
 

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,14 @@
+import { fileURLToPath, URL } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node"
+  },
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url))
+    }
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #2130 — a repeating garbage string like `;1R;1R;1R1R1R;1R;1R...` getting auto-typed into the terminal roughly half a second after navigating away from and back to an instance's console page.

Root cause: the daemon persists the raw PTY output stream to a log file forever, independent of whether a browser is attached. When the terminal page remounts, the entire historical log gets replayed into a freshly created xterm.js `Terminal` via `term.write()`. If a stray `ESC[6n` (cursor position query) was sitting unanswered in that backlog — emitted by a shell/tool while nobody was connected to answer it — xterm.js's own built-in Device Status Report handling fires during replay, synthesizes an `ESC[row;colR` reply, and pushes it through the same `onData` channel used for real keystrokes. That fabricated reply then gets forwarded to the live PTY as if typed, and the shell echoes it back — producing the reported garbage.

Fix: `useTerminal.ts` gains a `writeHistoryLog()` helper that suppresses `onData` forwarding for the duration of the backlog-hydration write only, using xterm.js's own write-completion callback to know exactly when replay ends. Live `stdout` writes during an active session are untouched, so genuine interactive DSR exchanges during real use keep working normally.

## Test plan

- [x] Added unit tests for the replay gate's state machine (begin/end/multiple cycles).
- [x] `cd frontend && npm test` — 4/4 passing.
- [x] `cd frontend && npm run type-check && npm run build` — clean.