### PR TITLE
fix: preserve mutex during queued handoff

### DIFF
--- a/panel/src/app/utils/sync.ts
+++ b/panel/src/app/utils/sync.ts
@@ -14,7 +14,9 @@ export async function execWithMutex<T>(fn: () => Promise<T>): Promise<T> {
     return await fn();
   } finally {
     releaseLock();
-    mutexMap.delete(fn);
+    if (!mutex.isLocked() && mutexMap.get(fn) === mutex) {
+      mutexMap.delete(fn);
+    }
   }
 }
 
@@ -29,6 +31,8 @@ export async function execWithMutexId<T>(id: string, fn: () => Promise<T>) {
     return await fn();
   } finally {
     releaseLock();
-    mutexIdMap.delete(id);
+    if (!mutex.isLocked() && mutexIdMap.get(id) === mutex) {
+      mutexIdMap.delete(id);
+    }
   }
 }


### PR DESCRIPTION
## Summary

- preserve the mutex-map entry while a queued caller owns the lock
- clean up only when the same mutex is still stored and is no longer locked
- apply the same correction to both `execWithMutex` and `execWithMutexId`

## Why

`async-mutex` transfers ownership to a queued waiter synchronously during `releaseLock()`. The previous unconditional map deletion removed that still-active mutex, allowing a third caller to create a new mutex for the same key and enter concurrently.

## Verification

- Three-caller regression for `execWithMutexId`: passed; the third caller stayed blocked until the second completed
- Equivalent regression for `execWithMutex`: passed
- Both event sequences are now `first:start → first:end → second:start → second:end → third:start → third:end`
- `cd panel && npm run build`: `webpack 5.105.3 compiled successfully` on panel 10.16.3
- `git diff --check`: passed

Fixes #2242