### PR TITLE
feat: proxy daemon data plane through the panel

### DIFF
--- a/frontend/src/components/NodeRemoteMappingEdit.vue
+++ b/frontend/src/components/NodeRemoteMappingEdit.vue
@@ -56,6 +56,12 @@ watch(remoteMappings, () => {
 </script>
 
 <template>
+  <a-alert
+    type="info"
+    show-icon
+    style="margin-bottom: 12px"
+    :message="t('TXT_CODE_REMOTE_MAPPING_PROXY_HINT')"
+  />
   <template v-if="remoteMappings.length > 0">
     <a-list item-layout="horizontal" :data-source="remoteMappings">
       <template #header>

--- a/frontend/src/hooks/useFileManager.ts
+++ b/frontend/src/hooks/useFileManager.ts
@@ -22,7 +22,11 @@ import uploadService from "@/services/uploadService";
 import { convertFileSize } from "@/tools/fileSize";
 import { compressFolder, scanDirectory, type ScanItem } from "@/tools/folderUploader";
 import { number2permission, permission2number } from "@/tools/permission";
-import { mapDaemonAddress, parseForwardAddress, type RemoteMappingEntry } from "@/tools/protocol";
+import {
+  resolveDaemonHttpBase,
+  type DataPlaneMission
+} from "@/tools/dataPlane";
+import { mapDaemonAddress, type RemoteMappingEntry } from "@/tools/protocol";
 import { removeTrail } from "@/tools/string";
 import { reportErrorMsg } from "@/tools/validator";
 import type {
@@ -40,6 +44,7 @@ import type { Key } from "ant-design-vue/es/table/interface";
 import { v4 } from "uuid";
 import { computed, createVNode, onMounted, reactive, ref, type VNodeRef } from "vue";
 
+/** @deprecated Prefer resolveDaemonHttpBase — kept for call sites that only need raw addr rewrite */
 export function getFileConfigAddr(config: { addr: string; remoteMappings?: RemoteMappingEntry[] }) {
   let addr = config.addr;
   if (config.remoteMappings) {
@@ -49,6 +54,10 @@ export function getFileConfigAddr(config: { addr: string; remoteMappings?: Remot
     }
   }
   return addr;
+}
+
+function resolveFileHttpBase(mission: DataPlaneMission, daemonId: string) {
+  return resolveDaemonHttpBase(mission, daemonId);
 }
 
 interface TabItem {
@@ -754,7 +763,7 @@ export const useFileManager = (instanceId: string = "", daemonId: string = "") =
           });
           if (!missionCfg.value) throw new Error(t("TXT_CODE_e8ce38c2"));
 
-          const addr = parseForwardAddress(getFileConfigAddr(missionCfg.value), "http");
+          const addr = resolveFileHttpBase(missionCfg.value, daemonId!);
           uploadService.append(
             f.file,
             addr,
@@ -842,7 +851,7 @@ export const useFileManager = (instanceId: string = "", daemonId: string = "") =
 
         if (!res.value) throw new Error(t("TXT_CODE_e8ce38c2"));
 
-        const addr = parseForwardAddress(getFileConfigAddr(res.value), "http");
+        const addr = resolveFileHttpBase(res.value, daemonId);
 
         const completionTracker = createUploadCompletionTracker(async () => {
           await waitForInstanceFileTasks(baselineTaskCount);
@@ -956,7 +965,7 @@ export const useFileManager = (instanceId: string = "", daemonId: string = "") =
         }
       });
       if (!downloadCfg.value) return null;
-      const addr = parseForwardAddress(getFileConfigAddr(downloadCfg.value), "http");
+      const addr = resolveFileHttpBase(downloadCfg.value, daemonId || "");
       const path = `/download/${downloadCfg.value.password}/${fileName}`;
       return addr + path;
     } catch (err: any) {

--- a/frontend/src/hooks/useSocketIo.ts
+++ b/frontend/src/hooks/useSocketIo.ts
@@ -1,3 +1,4 @@
+import { isDataPlaneProxyMode } from "@/tools/dataPlane";
 import { mapDaemonAddress, parseForwardAddress } from "@/tools/protocol";
 import { removeTrail } from "@/tools/string";
 import type { DefaultEventsMap } from "@socket.io/component-emitter";
@@ -16,6 +17,7 @@ export enum SocketStatus {
   Error = 0
 }
 
+/** Direct-mode socket: connect to daemon host with optional path prefix. */
 export function makeSocketIo(addr: string, prefix?: string) {
   prefix = removeTrail((prefix ?? "").trim(), "/");
   return io(parseForwardAddress(addr, "ws"), {
@@ -29,12 +31,32 @@ export function makeSocketIo(addr: string, prefix?: string) {
   });
 }
 
+/** Explicit Socket.IO options (used by data-plane proxy mode). */
+export function makeSocketIoWithOptions(url: string, path: string) {
+  return io(url, {
+    path: removeTrail(path.trim(), "/") || "/socket.io",
+    multiplex: false,
+    reconnectionDelayMax: 1000 * 10,
+    timeout: 1000 * 30,
+    reconnection: true,
+    reconnectionAttempts: 3,
+    rejectUnauthorized: false,
+    withCredentials: true
+  });
+}
+
 export function useSocketIoClient() {
   let socket: Socket<DefaultEventsMap, DefaultEventsMap> | undefined;
   const socketStatus = ref<SocketStatus>(SocketStatus.Connecting);
 
   const testFrontendSocket = async (remoteNode?: Partial<ComputedNodeInfo>) => {
     const nodeCfg = remoteNode;
+
+    // In proxy mode the browser never reaches daemons; panel availability is authoritative.
+    if (isDataPlaneProxyMode()) {
+      socketStatus.value = nodeCfg?.available ? SocketStatus.Connected : SocketStatus.Error;
+      return;
+    }
 
     if (!nodeCfg?.available || !nodeCfg.ip) {
       socketStatus.value = SocketStatus.Error;

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -4,7 +4,7 @@ import { t } from "@/lang/i18n";
 import { setUpTerminalStreamChannel } from "@/services/apis/instance";
 import { useAppConfigStore } from "@/stores/useAppConfigStore";
 import { toCopy } from "@/tools/copy";
-import { mapDaemonAddress, parseForwardAddress } from "@/tools/protocol";
+import { resolveDaemonSocketOptions } from "@/tools/dataPlane";
 import type { InstanceDetail } from "@/types";
 import { INSTANCE_STATUS_CODE } from "@/types/const";
 import type { DefaultEventsMap } from "@socket.io/component-emitter";
@@ -16,7 +16,7 @@ import { Terminal } from "@xterm/xterm";
 import EventEmitter from "eventemitter3";
 import type { Socket } from "socket.io-client";
 import { computed, onMounted, onUnmounted, ref, unref } from "vue";
-import { makeSocketIo } from "./useSocketIo";
+import { makeSocketIoWithOptions } from "./useSocketIo";
 import { createTerminalHistoryReplayGate } from "./terminalHistoryReplayGate";
 
 export const TERM_COLOR = {
@@ -103,22 +103,14 @@ export function useTerminal() {
     const remoteInfo = unref(res.value);
     if (!remoteInfo) throw new Error(t("TXT_CODE_181f2f08"));
 
-    let addr = remoteInfo.addr,
-      prefix = remoteInfo.prefix;
-    if (remoteInfo.remoteMappings) {
-      const mapped = mapDaemonAddress(remoteInfo.remoteMappings);
-      if (mapped) {
-        addr = mapped.addr;
-        prefix = mapped.prefix;
-      }
-    }
-    socketAddress.value = parseForwardAddress(addr, "ws");
+    const sockOpts = resolveDaemonSocketOptions(remoteInfo, config.daemonId);
+    socketAddress.value = sockOpts.url + sockOpts.path;
     const password = remoteInfo.password;
 
-    socket = makeSocketIo(addr, prefix);
+    socket = makeSocketIoWithOptions(sockOpts.url, sockOpts.path);
 
     socket.on("connect", () => {
-      console.log("[Socket.io] connect:", addr);
+      console.log("[Socket.io] connect:", socketAddress.value);
       socket?.emit("stream/auth", {
         data: { password }
       });
@@ -126,7 +118,7 @@ export function useTerminal() {
     });
 
     socket.on("connect_error", (error) => {
-      console.error("[Socket.io] Connect error: ", addr, error);
+      console.error("[Socket.io] Connect error: ", socketAddress.value, error);
       isConnect.value = false;
       events.emit("error", error);
     });
@@ -151,7 +143,7 @@ export function useTerminal() {
     });
 
     socket.on("reconnect", () => {
-      console.warn("[Socket.io] reconnect:", addr);
+      console.warn("[Socket.io] reconnect:", socketAddress.value);
       isConnect.value = true;
       socket?.emit("stream/auth", {
         data: { password }
@@ -160,7 +152,7 @@ export function useTerminal() {
 
     socket.on("disconnect", () => {
       if (!isManualDisconnect) {
-        console.warn("[Socket.io] disconnect:", addr);
+        console.warn("[Socket.io] disconnect:", socketAddress.value);
       }
       isConnect.value = false;
       events.emit("disconnect");

--- a/frontend/src/services/apis/fileManager.ts
+++ b/frontend/src/services/apis/fileManager.ts
@@ -207,6 +207,12 @@ export const uploadAddress = useDefineApi<
     password: string;
     addr: string;
     remoteMappings: RemoteMappingEntry[];
+    dataPlaneMode?: "proxy" | "direct";
+    proxy?: {
+      daemonId: string;
+      httpBase: string;
+      wsPath: string;
+    };
   }
 >({
   url: "/api/files/upload",
@@ -260,6 +266,12 @@ export const downloadAddress = useDefineApi<
     password: string;
     addr: string;
     remoteMappings: RemoteMappingEntry[];
+    dataPlaneMode?: "proxy" | "direct";
+    proxy?: {
+      daemonId: string;
+      httpBase: string;
+      wsPath: string;
+    };
   }
 >({
   url: "/api/files/download",

--- a/frontend/src/services/apis/instance.ts
+++ b/frontend/src/services/apis/instance.ts
@@ -13,6 +13,12 @@ export interface MissionPassportResponse {
   password: string;
   prefix: string;
   remoteMappings: RemoteMappingEntry[];
+  dataPlaneMode?: "proxy" | "direct";
+  proxy?: {
+    daemonId: string;
+    httpBase: string;
+    wsPath: string;
+  };
 }
 
 export const setUpTerminalStreamChannel = useDefineApi<
@@ -196,6 +202,12 @@ export const uploadAddress = useDefineApi<
     password: string;
     addr: string;
     remoteMappings: RemoteMappingEntry[];
+    dataPlaneMode?: "proxy" | "direct";
+    proxy?: {
+      daemonId: string;
+      httpBase: string;
+      wsPath: string;
+    };
   }
 >({
   url: "/api/instance/upload",

--- a/frontend/src/stores/useAppStateStore.ts
+++ b/frontend/src/stores/useAppStateStore.ts
@@ -27,7 +27,8 @@ export const useAppStateStore = createGlobalState(() => {
       businessId: "",
       allowChangeCmd: false,
       ssoEnabled: false,
-      ssoOnlyMode: false
+      ssoOnlyMode: false,
+      dataPlaneMode: "proxy"
     }
   });
 

--- a/frontend/src/tools/dataPlane.ts
+++ b/frontend/src/tools/dataPlane.ts
@@ -1,0 +1,89 @@
+import { useAppStateStore } from "@/stores/useAppStateStore";
+import {
+  mapDaemonAddress,
+  parseForwardAddress,
+  type RemoteMappingEntry
+} from "@/tools/protocol";
+
+export type DataPlaneMode = "proxy" | "direct";
+
+export type DataPlaneMission = {
+  password: string;
+  addr?: string;
+  prefix?: string;
+  remoteMappings?: RemoteMappingEntry[];
+  dataPlaneMode?: DataPlaneMode;
+  proxy?: {
+    daemonId: string;
+    httpBase: string;
+    wsPath: string;
+  };
+};
+
+export function getDataPlaneMode(): DataPlaneMode {
+  const { state } = useAppStateStore();
+  return state.settings?.dataPlaneMode === "direct" ? "direct" : "proxy";
+}
+
+export function isDataPlaneProxyMode(): boolean {
+  return getDataPlaneMode() === "proxy";
+}
+
+/**
+ * Resolve HTTP base URL for daemon file upload/download.
+ * Proxy mode: same-origin panel path. Direct mode: daemon public address.
+ */
+export function resolveDaemonHttpBase(
+  mission: DataPlaneMission,
+  daemonId: string
+): string {
+  const mode = mission.dataPlaneMode ?? getDataPlaneMode();
+  if (mode === "proxy") {
+    const base =
+      mission.proxy?.httpBase || `/api/daemon_proxy/${daemonId}`;
+    // Relative paths work with axios (prefixes ".") and window.open same-origin
+    if (base.startsWith("http://") || base.startsWith("https://")) return base;
+    return `${window.location.origin}${base.startsWith("/") ? base : `/${base}`}`;
+  }
+
+  let addr = mission.addr || "";
+  if (mission.remoteMappings) {
+    const mapped = mapDaemonAddress(mission.remoteMappings);
+    if (mapped) {
+      addr = mapped.addr + (mapped.prefix || "");
+    }
+  }
+  return parseForwardAddress(addr, "http");
+}
+
+/**
+ * Resolve Socket.IO connection options for terminal stream.
+ */
+export function resolveDaemonSocketOptions(
+  mission: DataPlaneMission,
+  daemonId: string
+): { url: string; path: string } {
+  const mode = mission.dataPlaneMode ?? getDataPlaneMode();
+  if (mode === "proxy") {
+    const wsPath =
+      mission.proxy?.wsPath || `/socket.io-daemon/${daemonId}`;
+    return {
+      url: window.location.origin,
+      path: wsPath
+    };
+  }
+
+  let addr = mission.addr || "";
+  let prefix = mission.prefix || "";
+  if (mission.remoteMappings) {
+    const mapped = mapDaemonAddress(mission.remoteMappings);
+    if (mapped) {
+      addr = mapped.addr;
+      prefix = mapped.prefix;
+    }
+  }
+  return {
+    url: parseForwardAddress(addr, "ws"),
+    path: (prefix || "").replace(/\/$/, "") + "/socket.io"
+  };
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -102,6 +102,8 @@ export interface Settings {
   ssoClientId: string;
   ssoClientSecret: string;
   ssoCallbackUrl: string;
+  /** proxy | direct — how browser reaches daemon data-plane (files/terminal) */
+  dataPlaneMode?: "proxy" | "direct";
 }
 
 export interface ImageInfo {
@@ -262,5 +264,7 @@ export interface PanelStatus {
     panelId: string;
     ssoEnabled: boolean;
     ssoOnlyMode: boolean;
+    /** proxy: browser only reaches panel; direct: browser may connect to daemons */
+    dataPlaneMode?: "proxy" | "direct";
   };
 }

--- a/frontend/src/widgets/Settings.vue
+++ b/frontend/src/widgets/Settings.vue
@@ -398,6 +398,9 @@ onMounted(async () => {
   const cfg = await getSettingsConfig();
   formData.value = res.value!;
   const fd = formData.value as any;
+  if (fd.dataPlaneMode !== "direct" && fd.dataPlaneMode !== "proxy") {
+    fd.dataPlaneMode = "proxy";
+  }
   ssoSnapshot.value = {
     ssoType: fd.ssoType || "oidc",
     ssoIssuer: fd.ssoIssuer || "",
@@ -835,6 +838,29 @@ onUnmounted(() => {
                         :value="item.value"
                       >
                         {{ item.label }}
+                      </a-select-option>
+                    </a-select>
+                  </a-form-item>
+
+                  <a-form-item>
+                    <a-typography-title :level="5">
+                      {{ t("TXT_CODE_DATA_PLANE_MODE") }}
+                    </a-typography-title>
+                    <a-typography-paragraph>
+                      <a-typography-text type="secondary">
+                        {{ t("TXT_CODE_DATA_PLANE_MODE_DESC") }}
+                      </a-typography-text>
+                    </a-typography-paragraph>
+
+                    <a-select
+                      v-model:value.prop="(formData as any).dataPlaneMode"
+                      style="max-width: 420px"
+                    >
+                      <a-select-option value="proxy">
+                        {{ t("TXT_CODE_DATA_PLANE_MODE_PROXY") }}
+                      </a-select-option>
+                      <a-select-option value="direct">
+                        {{ t("TXT_CODE_DATA_PLANE_MODE_DIRECT") }}
                       </a-select-option>
                     </a-select>
                   </a-form-item>

--- a/frontend/src/widgets/setupApp/CreateInstanceForm.vue
+++ b/frontend/src/widgets/setupApp/CreateInstanceForm.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
-import { getFileConfigAddr } from "@/hooks/useFileManager";
 import { INSTANCE_TYPE_TRANSLATION, TYPE_MINECRAFT_BUNGEECORD } from "@/hooks/useInstance";
 import { QUICKSTART_ACTION_TYPE, QUICKSTART_METHOD } from "@/hooks/widgets/quickStartFlow";
 import { t } from "@/lang/i18n";
 import { createInstance as createInstanceApi, uploadAddress } from "@/services/apis/instance";
 import uploadService, { UploadFiles } from "@/services/uploadService";
-import { parseForwardAddress } from "@/tools/protocol";
+import { resolveDaemonHttpBase } from "@/tools/dataPlane";
 import { reportErrorMsg } from "@/tools/validator";
 import { defaultInstanceInfo } from "@/types/const";
 import {
@@ -162,7 +161,7 @@ const selectedFile = async () => {
     uploadStartCallback = () => {
       uploadStarted.value = true;
     };
-    const addr = parseForwardAddress(getFileConfigAddr(cfg.value), "http");
+    const addr = resolveDaemonHttpBase(cfg.value, props.daemonId);
     const task = uploadService.append(
       uFile.value!,
       addr,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -65,6 +65,12 @@ export default defineConfig({
       "/socket.io": {
         target: "ws://localhost:23333",
         ws: true
+      },
+      // Panel data-plane proxy for Socket.IO terminal streams (browser → panel → daemon)
+      "/socket.io-daemon": {
+        target: "ws://localhost:23333",
+        ws: true,
+        changeOrigin: true
       }
     }
   },

--- a/languages/en_US.json
+++ b/languages/en_US.json
@@ -3448,5 +3448,10 @@
   "TXT_CODE_6542489a": "Example: /dev/sda:10MB",
   "TXT_CODE_9d2e6d5e": "Device Write Rate Limit (BPS)",
   "TXT_CODE_2b2ff3ff": "Limit the write rate of specific block devices for the container. Format: /dev/sda:5MB. Separate multiple devices with commas.",
-  "TXT_CODE_f0dc9eca": "Example: /dev/sda:5MB"
+  "TXT_CODE_f0dc9eca": "Example: /dev/sda:5MB",
+  "TXT_CODE_DATA_PLANE_MODE": "Data plane mode",
+  "TXT_CODE_DATA_PLANE_MODE_DESC": "Controls how the browser reaches daemon nodes for terminals and file transfer. Proxy mode only requires access to the panel; Direct mode requires the browser to reach each node (legacy).",
+  "TXT_CODE_DATA_PLANE_MODE_PROXY": "Proxy (browser → panel → node)",
+  "TXT_CODE_DATA_PLANE_MODE_DIRECT": "Direct (browser → node)",
+  "TXT_CODE_REMOTE_MAPPING_PROXY_HINT": "Address mappings only apply in Direct data-plane mode. In Proxy mode the browser never connects to nodes."
 }

--- a/languages/zh_CN.json
+++ b/languages/zh_CN.json
@@ -3448,5 +3448,10 @@
   "TXT_CODE_6542489a": "例如: /dev/sda:10MB",
   "TXT_CODE_9d2e6d5e": "设备写入速率限制 (BPS)",
   "TXT_CODE_2b2ff3ff": "限制容器对特定块设备的写入速率。格式如: /dev/sda:5MB。多个设备用逗号分隔。",
-  "TXT_CODE_f0dc9eca": "例如: /dev/sda:5MB"
+  "TXT_CODE_f0dc9eca": "例如: /dev/sda:5MB",
+  "TXT_CODE_DATA_PLANE_MODE": "数据面模式",
+  "TXT_CODE_DATA_PLANE_MODE_DESC": "控制浏览器如何访问节点的终端与文件传输。代理模式只需能访问面板；直连模式要求浏览器能访问每个节点（旧模式）。",
+  "TXT_CODE_DATA_PLANE_MODE_PROXY": "代理（浏览器 → 面板 → 节点）",
+  "TXT_CODE_DATA_PLANE_MODE_DIRECT": "直连（浏览器 → 节点）",
+  "TXT_CODE_REMOTE_MAPPING_PROXY_HINT": "地址映射仅在直连数据面模式下生效。代理模式下浏览器不会连接节点。"
 }

--- a/panel/src/app.ts
+++ b/panel/src/app.ts
@@ -17,6 +17,11 @@ import { $t } from "./app/i18n";
 import { mountRouters } from "./app/index";
 import { preCheckMiddleware } from "./app/middleware/precheck";
 import { middleware as protocolMiddleware } from "./app/middleware/protocol";
+import { daemonHttpProxyMiddleware } from "./app/service/daemon_http_proxy";
+import {
+  attachDaemonSocketUpgrade,
+  daemonSocketIoHttpProxyMiddleware
+} from "./app/service/daemon_socket_proxy";
 import { logger } from "./app/service/log";
 import SystemRemoteService from "./app/service/remote_service";
 import SystemUser from "./app/service/user_service";
@@ -47,6 +52,9 @@ function setupHttp(
   } else {
     httpServer = http.createServer(koaApp.callback());
   }
+
+  // Transparent Socket.IO upgrade proxy: browser → panel → daemon
+  attachDaemonSocketUpgrade(httpServer);
 
   httpServer.on("error", (err) => {
     logger.error($t("TXT_CODE_app.httpSetupError"));
@@ -136,6 +144,46 @@ _  /  / / / /___  ____/ /_  /  / / / /_/ /_  / / / /_/ /_  /_/ //  __/  /
     // When Koa is attacked by a short connection flood, it is easy for error messages to swipe the screen, which may indirectly affect the operation of some applications
   });
 
+  // Session must run before the daemon HTTP proxy so uploads/downloads can authenticate.
+  // Panel path prefix (if any) must be stripped before daemon proxy path matching.
+  // Daemon proxy must run before koa-body so large multipart bodies stream to nodes.
+  app.keys = [v4()];
+  app.use(
+    session(
+      {
+        key: v4(),
+        maxAge: 86400000,
+        overwrite: true,
+        httpOnly: true,
+        signed: true,
+        rolling: false,
+        renew: false,
+        secure: false
+      },
+      app
+    )
+  );
+
+  if (systemConfig && systemConfig.prefix != "") {
+    const prefix = systemConfig.prefix;
+    app.use(async (ctx, next) => {
+      if (ctx.url.startsWith(prefix)) {
+        const orig = ctx.url;
+        ctx.url = ctx.url.slice(prefix.length);
+        if (!ctx.url.startsWith("/")) {
+          ctx.url = "/" + ctx.url;
+        }
+        await next();
+        ctx.url = orig;
+      } else {
+        ctx.redirect(removeTrail(prefix, "/") + ctx.url);
+      }
+    });
+  }
+
+  app.use(daemonHttpProxyMiddleware);
+  app.use(daemonSocketIoHttpProxyMiddleware);
+
   app.use(preCheckMiddleware);
   app.use(
     koaBody({
@@ -157,23 +205,6 @@ _  /  / / / /___  ____/ /_  /  / / / /_/ /_  / / / /_/ /_  /_/ //  __/  /
     })
   );
 
-  app.keys = [v4()];
-  app.use(
-    session(
-      {
-        key: v4(),
-        maxAge: 86400000,
-        overwrite: true,
-        httpOnly: true,
-        signed: true,
-        rolling: false,
-        renew: false,
-        secure: false
-      },
-      app
-    )
-  );
-
   app.use(async (ctx, next) => {
     const ignoreUrls = ["/api/overview", "/api/files/status"];
     for (const iterator of ignoreUrls) {
@@ -181,23 +212,6 @@ _  /  / / / /___  ____/ /_  /  / / / /_/ /_  / / / /_/ /_  /_/ //  __/  /
     }
     await next();
   });
-
-  if (systemConfig && systemConfig.prefix != "") {
-    const prefix = systemConfig.prefix;
-    app.use(async (ctx, next) => {
-      if (ctx.url.startsWith(prefix)) {
-        const orig = ctx.url;
-        ctx.url = ctx.url.slice(prefix.length);
-        if (!ctx.url.startsWith("/")) {
-          ctx.url = "/" + ctx.url;
-        }
-        await next();
-        ctx.url = orig;
-      } else {
-        ctx.redirect(removeTrail(prefix, "/") + ctx.url);
-      }
-    });
-  }
 
   // HTTP response compression
   systemConfig?.gzip && app.use(compress({ threshold: 1024 }));

--- a/panel/src/app/entity/setting.ts
+++ b/panel/src/app/entity/setting.ts
@@ -95,4 +95,13 @@ export default class SystemConfig {
   sslPemPath = "";
   // SSL private key file path (.key)
   sslKeyPath = "";
+
+  /**
+   * Data-plane transport mode for browser ↔ daemon traffic
+   * (terminal stream, file upload/download).
+   *
+   * - "proxy": browser only talks to the panel; panel reverse-proxies to daemons.
+   * - "direct": legacy mode; browser connects to each daemon (needs public node access).
+   */
+  dataPlaneMode: "proxy" | "direct" = "proxy";
 }

--- a/panel/src/app/middleware/precheck.ts
+++ b/panel/src/app/middleware/precheck.ts
@@ -13,6 +13,12 @@ export function isUploadRequest(ctx: Context) {
  * occupying machine disk space.
  */
 export async function preCheckMiddleware(ctx: Context, next: () => Promise<void>) {
+  // Daemon data-plane proxy streams multipart to nodes; do not treat as panel asset upload.
+  const path = ctx.path || "";
+  if (path.startsWith("/api/daemon_proxy/") || path.startsWith("/socket.io-daemon/")) {
+    return await next();
+  }
+
   if (isUploadRequest(ctx)) {
     const user = getUserFromCtx(ctx);
     const isAdmin = user?.permission === ROLE.ADMIN;

--- a/panel/src/app/routers/filemananger_router.ts
+++ b/panel/src/app/routers/filemananger_router.ts
@@ -8,6 +8,7 @@ import { operationLogger } from "../service/operation_logger";
 import { getUserPermission, getUserUuid } from "../service/passport_service";
 import { timeUuid } from "../service/password";
 import { isHaveInstanceByUuid, isTopPermissionByUuid } from "../service/permission_service";
+import { buildDataPlaneMissionResponse } from "../service/daemon_proxy_utils";
 import RemoteRequest from "../service/remote_command";
 import RemoteServiceSubsystem from "../service/remote_service";
 import { systemConfig } from "../setting";
@@ -415,8 +416,6 @@ router.all(
       const fileName = String(ctx.query.file_name);
       const remoteService = RemoteServiceSubsystem.getInstance(daemonId);
       if (!remoteService) throw new Error($t("TXT_CODE_dd559000") + ` Daemon ID: ${daemonId}`);
-      const addr = remoteService.config.fullAddr;
-      const remoteMappings = remoteService.config.getConvertedRemoteMappings();
       const password = timeUuid();
       await new RemoteRequest(remoteService).request("passport/register", {
         name: "download",
@@ -433,11 +432,12 @@ router.all(
         daemon_id: daemonId,
         file: fileName
       });
-      ctx.body = {
-        password,
-        addr,
-        remoteMappings
-      };
+      const body = buildDataPlaneMissionResponse(daemonId, password, remoteService);
+      // File APIs historically return fullAddr (ip:port + prefix) as `addr`
+      if (body.dataPlaneMode === "direct") {
+        body.addr = remoteService.config.fullAddr;
+      }
+      ctx.body = body;
     } catch (err) {
       ctx.body = err;
     }
@@ -455,8 +455,6 @@ router.all(
       const uploadDir = String(ctx.query.upload_dir);
       const remoteService = RemoteServiceSubsystem.getInstance(daemonId);
       if (!remoteService) throw new Error($t("TXT_CODE_dd559000") + ` Daemon ID: ${daemonId}`);
-      const addr = remoteService.config.fullAddr;
-      const remoteMappings = remoteService.config.getConvertedRemoteMappings();
       const password = timeUuid();
       await new RemoteRequest(remoteService).request("passport/register", {
         name: "upload",
@@ -472,11 +470,11 @@ router.all(
         instance_id: instanceUuid,
         daemon_id: daemonId
       });
-      ctx.body = {
-        password,
-        addr,
-        remoteMappings
-      };
+      const body = buildDataPlaneMissionResponse(daemonId, password, remoteService);
+      if (body.dataPlaneMode === "direct") {
+        body.addr = remoteService.config.fullAddr;
+      }
+      ctx.body = body;
     } catch (err) {
       ctx.body = err;
     }

--- a/panel/src/app/routers/instance_admin_router.ts
+++ b/panel/src/app/routers/instance_admin_router.ts
@@ -13,6 +13,7 @@ import { operationLogger } from "../service/operation_logger";
 import { getUserUuid } from "../service/passport_service";
 import { timeUuid } from "../service/password";
 import { isHaveInstanceByUuid, isTopPermissionByUuid } from "../service/permission_service";
+import { buildDataPlaneMissionResponse } from "../service/daemon_proxy_utils";
 import RemoteRequest from "../service/remote_command";
 import RemoteServiceSubsystem from "../service/remote_service";
 import userSystem from "../service/user_service";
@@ -94,8 +95,6 @@ router.post(
         instance_name: result.nickname
       });
       // Send a cross-end file upload task to the daemon
-      const addr = remoteService.config.fullAddr;
-      const remoteMappings = remoteService.config.getConvertedRemoteMappings();
       const password = timeUuid();
       await new RemoteRequest(remoteService).request("passport/register", {
         name: "upload",
@@ -105,12 +104,13 @@ router.post(
           instanceUuid: newInstanceUuid
         }
       });
-      ctx.body = {
-        instanceUuid: newInstanceUuid,
-        password,
-        addr,
-        remoteMappings
-      };
+      const body = buildDataPlaneMissionResponse(daemonId, password, remoteService, {
+        instanceUuid: newInstanceUuid
+      });
+      if (body.dataPlaneMode === "direct") {
+        body.addr = remoteService.config.fullAddr;
+      }
+      ctx.body = body;
     } catch (err) {
       ctx.body = err;
     }

--- a/panel/src/app/routers/instance_operate_router.ts
+++ b/panel/src/app/routers/instance_operate_router.ts
@@ -10,6 +10,7 @@ import { operationLogger } from "../service/operation_logger";
 import { getUserPermission, getUserUuid } from "../service/passport_service";
 import { timeUuid } from "../service/password";
 import { isHaveInstanceByUuid, isTopPermissionByUuid } from "../service/permission_service";
+import { buildDataPlaneMissionResponse } from "../service/daemon_proxy_utils";
 import RemoteRequest, { RemoteRequestTimeoutError } from "../service/remote_command";
 import RemoteServiceSubsystem from "../service/remote_service";
 import { systemConfig } from "../setting";
@@ -238,9 +239,6 @@ router.post(
       const instanceUuid = String(ctx.query.uuid);
       const remoteService = RemoteServiceSubsystem.getInstance(daemonId);
       if (!remoteService) throw new Error($t("TXT_CODE_dd559000") + ` Daemon ID: ${daemonId}`);
-      const addr = remoteService.config.addr;
-      const prefix = remoteService.config.prefix;
-      const remoteMappings = remoteService.config.getConvertedRemoteMappings();
       const password = timeUuid();
       await new RemoteRequest(remoteService).request("passport/register", {
         name: "stream_channel",
@@ -249,12 +247,13 @@ router.post(
           instanceUuid
         }
       });
-      ctx.body = {
-        password,
-        addr,
-        prefix,
-        remoteMappings
-      };
+      // stream uses addr + prefix separately (not fullAddr)
+      const body = buildDataPlaneMissionResponse(daemonId, password, remoteService);
+      if (body.dataPlaneMode === "direct") {
+        body.addr = remoteService.config.addr;
+        body.prefix = remoteService.config.prefix;
+      }
+      ctx.body = body;
     } catch (err) {
       ctx.body = err;
     }

--- a/panel/src/app/routers/login_router.ts
+++ b/panel/src/app/routers/login_router.ts
@@ -98,7 +98,8 @@ router.all(
         allowChangeCmd: systemConfig?.allowChangeCmd || false,
         panelId: systemConfig?.panelId || null,
         ssoEnabled: systemConfig?.ssoEnabled || false,
-        ssoOnlyMode: systemConfig?.ssoOnlyMode || false
+        ssoOnlyMode: systemConfig?.ssoOnlyMode || false,
+        dataPlaneMode: systemConfig?.dataPlaneMode === "direct" ? "direct" : "proxy"
       } as Partial<SystemConfig>
     };
   }

--- a/panel/src/app/routers/settings_router.ts
+++ b/panel/src/app/routers/settings_router.ts
@@ -54,6 +54,13 @@ router.put("/setting", permission({ level: ROLE.ADMIN }), async (ctx) => {
     if (config.loginInfo != null) systemConfig.loginInfo = String(config.loginInfo);
     if (config.canFileManager != null) systemConfig.canFileManager = Boolean(config.canFileManager);
     if (config.allowUsePreset != null) systemConfig.allowUsePreset = Boolean(config.allowUsePreset);
+    if (config.dataPlaneMode != null) {
+      const mode = String(config.dataPlaneMode);
+      if (mode !== "proxy" && mode !== "direct") {
+        throw new Error("dataPlaneMode must be 'proxy' or 'direct'");
+      }
+      systemConfig.dataPlaneMode = mode;
+    }
 
     if (config.businessMode != null) systemConfig.businessMode = Boolean(config.businessMode);
     if (config.businessId != null) systemConfig.businessId = String(config.businessId);

--- a/panel/src/app/service/daemon_http_proxy.ts
+++ b/panel/src/app/service/daemon_http_proxy.ts
@@ -1,0 +1,123 @@
+import type { Context, Middleware, Next } from "koa";
+import RemoteServiceSubsystem from "./remote_service";
+import { getUserFromCtx } from "./passport_service";
+import { logger } from "./log";
+import {
+  buildUpstreamUrl,
+  DAEMON_HTTP_PROXY_PREFIX,
+  filterRequestHeaders,
+  filterResponseHeaders,
+  parseDaemonProxyPath,
+  pickHttpModule
+} from "./daemon_proxy_utils";
+
+function isAuthenticated(ctx: Context): boolean {
+  const user = getUserFromCtx(ctx as any);
+  return !!(user && typeof user.permission === "number" && user.permission >= 1);
+}
+
+function sendPlain(ctx: Context, status: number, message: string) {
+  ctx.status = status;
+  ctx.type = "text/plain";
+  ctx.body = message;
+}
+
+/**
+ * Streaming reverse proxy: Browser → Panel → Daemon HTTP.
+ * Must run after session middleware and before koa-body so upload bodies are not buffered.
+ */
+export const daemonHttpProxyMiddleware: Middleware = async (ctx: Context, next: Next) => {
+  const pathname = ctx.path || ctx.URL.pathname;
+  if (!pathname.startsWith(DAEMON_HTTP_PROXY_PREFIX)) {
+    return await next();
+  }
+
+  // CORS preflight for same-site tools; still require auth for real methods
+  if (ctx.method === "OPTIONS") {
+    ctx.status = 204;
+    ctx.set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
+    ctx.set("Access-Control-Allow-Headers", "Content-Type, X-Requested-With, Cookie");
+    return;
+  }
+
+  if (!isAuthenticated(ctx)) {
+    return sendPlain(ctx, 403, "Access denied: login required");
+  }
+
+  const parsed = parseDaemonProxyPath(pathname);
+  if (!parsed) {
+    return sendPlain(ctx, 400, "Invalid daemon proxy path");
+  }
+
+  const remote = RemoteServiceSubsystem.getInstance(parsed.daemonId);
+  if (!remote) {
+    return sendPlain(ctx, 404, `Daemon not found: ${parsed.daemonId}`);
+  }
+
+  let upstreamUrl: URL;
+  try {
+    upstreamUrl = buildUpstreamUrl(remote, parsed.restPath, ctx.search || "");
+  } catch (err: any) {
+    logger.warn(`[daemon-proxy] bad upstream URL for ${parsed.daemonId}: ${err?.message}`);
+    return sendPlain(ctx, 502, "Bad daemon address");
+  }
+
+  // Stream the raw Node request/response; do not use Koa body serialization
+  ctx.respond = false;
+  const req = ctx.req;
+  const res = ctx.res;
+
+  const headers = filterRequestHeaders(req.headers);
+  headers["host"] = upstreamUrl.host;
+
+  const lib = pickHttpModule(upstreamUrl);
+  const proxyReq = lib.request(
+    {
+      protocol: upstreamUrl.protocol,
+      hostname: upstreamUrl.hostname,
+      port: upstreamUrl.port,
+      path: upstreamUrl.pathname + upstreamUrl.search,
+      method: req.method,
+      headers,
+      rejectUnauthorized: false,
+      timeout: 0
+    },
+    (proxyRes) => {
+      const outHeaders = filterResponseHeaders(proxyRes.headers);
+      res.writeHead(proxyRes.statusCode || 502, outHeaders as any);
+      proxyRes.pipe(res);
+    }
+  );
+
+  proxyReq.on("timeout", () => {
+    proxyReq.destroy();
+    if (!res.headersSent) {
+      res.writeHead(504, { "Content-Type": "text/plain" });
+      res.end("Daemon proxy timeout");
+    } else {
+      res.destroy();
+    }
+  });
+
+  proxyReq.on("error", (err) => {
+    logger.warn(
+      `[daemon-proxy] upstream error daemon=${parsed.daemonId} path=${parsed.restPath}: ${err.message}`
+    );
+    if (!res.headersSent) {
+      res.writeHead(502, { "Content-Type": "text/plain" });
+      res.end("Bad gateway: cannot reach daemon");
+    } else {
+      res.destroy();
+    }
+  });
+
+  req.on("aborted", () => {
+    proxyReq.destroy();
+  });
+
+  res.on("close", () => {
+    proxyReq.destroy();
+  });
+
+  req.pipe(proxyReq);
+};

--- a/panel/src/app/service/daemon_proxy_utils.ts
+++ b/panel/src/app/service/daemon_proxy_utils.ts
@@ -1,0 +1,177 @@
+import http from "http";
+import https from "https";
+import { URL } from "url";
+import { removeTrail } from "mcsmanager-common";
+import type RemoteService from "../entity/remote_service";
+import { systemConfig } from "../setting";
+
+export type DataPlaneMode = "proxy" | "direct";
+
+export const DAEMON_HTTP_PROXY_PREFIX = "/api/daemon_proxy";
+export const DAEMON_SOCKET_PROXY_PATH_PREFIX = "/socket.io-daemon";
+
+export function getDataPlaneMode(): DataPlaneMode {
+  const mode = systemConfig?.dataPlaneMode;
+  if (mode === "direct") return "direct";
+  return "proxy";
+}
+
+export function isDataPlaneProxyMode(): boolean {
+  return getDataPlaneMode() === "proxy";
+}
+
+/**
+ * Build the daemon HTTP(S) origin + prefix used when the panel talks to a node.
+ * Mirrors RemoteService.connect TLS selection: panel SSL upgrades plain targets to HTTPS.
+ */
+export function getDaemonHttpOrigin(remote: RemoteService): string {
+  const config = remote.config;
+  let host = config.ip.trim();
+  let protocol = "http:";
+
+  if (host.toLowerCase().startsWith("wss://")) {
+    protocol = "https:";
+    host = host.slice(6);
+  } else if (host.toLowerCase().startsWith("ws://")) {
+    protocol = "http:";
+    host = host.slice(5);
+  } else if (host.toLowerCase().startsWith("https://")) {
+    protocol = "https:";
+    host = host.slice(8);
+  } else if (host.toLowerCase().startsWith("http://")) {
+    protocol = "http:";
+    host = host.slice(7);
+  }
+
+  // Strip path fragments if present in the host field
+  host = host.split("/")[0];
+
+  if (systemConfig?.ssl && protocol === "http:") {
+    protocol = "https:";
+  }
+
+  const prefix = config.canonicalPrefix || "";
+  return `${protocol}//${host}:${config.port}${prefix}`;
+}
+
+export function getDaemonWsOrigin(remote: RemoteService): string {
+  return getDaemonHttpOrigin(remote).replace(/^http/, "ws");
+}
+
+export function getDaemonSocketIoPath(remote: RemoteService): string {
+  const prefix = remote.config.canonicalPrefix || "";
+  return removeTrail(prefix, "/") + "/socket.io";
+}
+
+/** Response shape for stream/file mission minting endpoints. */
+export function buildDataPlaneMissionResponse(
+  daemonId: string,
+  password: string,
+  remote: RemoteService,
+  extra: Record<string, unknown> = {}
+) {
+  if (!isDataPlaneProxyMode()) {
+    return {
+      password,
+      addr: remote.config.addr,
+      fullAddr: remote.config.fullAddr,
+      prefix: remote.config.prefix,
+      remoteMappings: remote.config.getConvertedRemoteMappings(),
+      dataPlaneMode: "direct" as const,
+      ...extra
+    };
+  }
+
+  return {
+    password,
+    // Empty so older clients cannot reach the real node by accident
+    addr: "",
+    fullAddr: "",
+    prefix: "",
+    remoteMappings: [],
+    dataPlaneMode: "proxy" as const,
+    proxy: {
+      daemonId,
+      httpBase: `${DAEMON_HTTP_PROXY_PREFIX}/${daemonId}`,
+      wsPath: `${DAEMON_SOCKET_PROXY_PATH_PREFIX}/${daemonId}`
+    },
+    ...extra
+  };
+}
+
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailers",
+  "transfer-encoding",
+  "upgrade",
+  "host"
+]);
+
+export function filterRequestHeaders(
+  headers: http.IncomingHttpHeaders
+): http.OutgoingHttpHeaders {
+  const out: http.OutgoingHttpHeaders = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (value == null) continue;
+    if (HOP_BY_HOP_HEADERS.has(key.toLowerCase())) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+export function filterResponseHeaders(
+  headers: http.IncomingHttpHeaders
+): http.OutgoingHttpHeaders {
+  const out: http.OutgoingHttpHeaders = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (value == null) continue;
+    const lower = key.toLowerCase();
+    if (lower === "connection" || lower === "keep-alive") continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+export function parseDaemonProxyPath(
+  urlPath: string
+): { daemonId: string; restPath: string } | null {
+  const prefix = DAEMON_HTTP_PROXY_PREFIX;
+  if (!urlPath.startsWith(prefix + "/") && urlPath !== prefix) return null;
+  const after = urlPath.slice(prefix.length);
+  const m = after.match(/^\/([^/]+)(\/.*)?$/);
+  if (!m) return null;
+  return {
+    daemonId: decodeURIComponent(m[1]),
+    restPath: m[2] || "/"
+  };
+}
+
+/**
+ * Parse /socket.io-daemon/:daemonId[/...][?query]
+ * Socket.IO client uses path option = /socket.io-daemon/:daemonId so Engine.IO
+ * requests look like /socket.io-daemon/:daemonId/?EIO=4&transport=polling
+ */
+export function parseDaemonSocketProxyPath(
+  urlPathname: string
+): { daemonId: string } | null {
+  const prefix = DAEMON_SOCKET_PROXY_PATH_PREFIX;
+  if (!urlPathname.startsWith(prefix + "/")) return null;
+  const after = urlPathname.slice(prefix.length + 1);
+  const daemonId = decodeURIComponent(after.split("/")[0].split("?")[0]);
+  if (!daemonId) return null;
+  return { daemonId };
+}
+
+export function buildUpstreamUrl(remote: RemoteService, restPath: string, search: string): URL {
+  const base = getDaemonHttpOrigin(remote);
+  const joined = removeTrail(base, "/") + restPath + (search || "");
+  return new URL(joined);
+}
+
+export function pickHttpModule(url: URL) {
+  return url.protocol === "https:" ? https : http;
+}

--- a/panel/src/app/service/daemon_socket_proxy.ts
+++ b/panel/src/app/service/daemon_socket_proxy.ts
@@ -1,0 +1,277 @@
+import http from "http";
+import https from "https";
+import type { Context, Middleware, Next } from "koa";
+import type { Socket as NetSocket } from "net";
+import type { Duplex } from "stream";
+import { URL } from "url";
+import { getUserFromCtx } from "./passport_service";
+import RemoteServiceSubsystem from "./remote_service";
+import { logger } from "./log";
+import { systemConfig } from "../setting";
+import {
+  DAEMON_HTTP_PROXY_PREFIX,
+  DAEMON_SOCKET_PROXY_PATH_PREFIX,
+  filterRequestHeaders,
+  getDaemonHttpOrigin,
+  getDaemonSocketIoPath,
+  parseDaemonSocketProxyPath,
+  pickHttpModule
+} from "./daemon_proxy_utils";
+
+function stripPanelPrefix(url: string): string {
+  const prefix = systemConfig?.prefix;
+  if (!prefix) return url;
+  try {
+    const u = new URL(url, "http://localhost");
+    if (u.pathname.startsWith(prefix)) {
+      let path = u.pathname.slice(prefix.length);
+      if (!path.startsWith("/")) path = "/" + path;
+      return path + u.search;
+    }
+  } catch {
+    if (url.startsWith(prefix)) {
+      let rest = url.slice(prefix.length);
+      if (!rest.startsWith("/")) rest = "/" + rest;
+      return rest;
+    }
+  }
+  return url;
+}
+
+/**
+ * Socket.IO / Engine.IO requests use path = /socket.io-daemon/:daemonId
+ * and must be rewritten to the daemon's {prefix}/socket.io path.
+ *
+ * Handles both:
+ *  - HTTP long-polling (via shouldHandleHttp)
+ *  - WebSocket upgrade (via attachUpgradeHandler)
+ */
+
+function rewriteSocketIoPath(url: string, daemonSocketPath: string): { path: string; search: string } {
+  // Incoming: /socket.io-daemon/:daemonId/?EIO=4&transport=...
+  //         or /socket.io-daemon/:daemonId?EIO=4...
+  const u = new URL(url, "http://localhost");
+  const parsed = parseDaemonSocketProxyPath(u.pathname);
+  if (!parsed) {
+    return { path: u.pathname, search: u.search };
+  }
+  // Engine.IO may append / or nothing after the custom path
+  // socket.io-client with path: "/socket.io-daemon/xxx" requests:
+  //   /socket.io-daemon/xxx/?EIO=4&transport=polling
+  const suffix = u.pathname.slice(
+    `${DAEMON_SOCKET_PROXY_PATH_PREFIX}/${parsed.daemonId}`.length
+  );
+  // suffix is typically "/" or ""
+  const upstreamPath = daemonSocketPath + (suffix || "/");
+  return { path: upstreamPath, search: u.search };
+}
+
+export function isDaemonSocketProxyUrl(url: string | undefined): boolean {
+  if (!url) return false;
+  try {
+    const u = new URL(url, "http://localhost");
+    return u.pathname.startsWith(DAEMON_SOCKET_PROXY_PATH_PREFIX + "/");
+  } catch {
+    return url.startsWith(DAEMON_SOCKET_PROXY_PATH_PREFIX + "/");
+  }
+}
+
+export function isDaemonHttpProxyUrl(url: string | undefined): boolean {
+  if (!url) return false;
+  try {
+    const u = new URL(url, "http://localhost");
+    return u.pathname.startsWith(DAEMON_HTTP_PROXY_PREFIX + "/");
+  } catch {
+    return url.startsWith(DAEMON_HTTP_PROXY_PREFIX + "/");
+  }
+}
+
+/**
+ * Koa middleware: stream Engine.IO long-polling HTTP through the panel.
+ * WebSocket upgrades are handled separately via attachDaemonSocketUpgrade.
+ */
+export const daemonSocketIoHttpProxyMiddleware: Middleware = async (
+  ctx: Context,
+  next: Next
+) => {
+  const pathname = ctx.path || ctx.URL.pathname;
+  if (!pathname.startsWith(DAEMON_SOCKET_PROXY_PATH_PREFIX + "/")) {
+    return await next();
+  }
+
+  if (ctx.method === "OPTIONS") {
+    ctx.status = 204;
+    return;
+  }
+
+  const user = getUserFromCtx(ctx as any);
+  if (!(user && typeof user.permission === "number" && user.permission >= 1)) {
+    ctx.status = 403;
+    ctx.body = "Access denied: login required";
+    return;
+  }
+
+  const parsed = parseDaemonSocketProxyPath(pathname);
+  if (!parsed) {
+    ctx.status = 400;
+    ctx.body = "Invalid socket proxy path";
+    return;
+  }
+
+  const remote = RemoteServiceSubsystem.getInstance(parsed.daemonId);
+  if (!remote) {
+    ctx.status = 404;
+    ctx.body = "Daemon not found";
+    return;
+  }
+
+  const daemonSocketPath = getDaemonSocketIoPath(remote);
+  // ctx.url is already prefix-stripped by panel middleware when applicable
+  const rewritten = rewriteSocketIoPath(ctx.url, daemonSocketPath);
+  const base = getDaemonHttpOrigin(remote);
+  const upstreamUrl = new URL(base);
+  const fullPath = rewritten.path + rewritten.search;
+
+  ctx.respond = false;
+  const req = ctx.req;
+  const res = ctx.res;
+
+  const headers = filterRequestHeaders(req.headers);
+  headers["host"] = upstreamUrl.host;
+
+  const lib = pickHttpModule(upstreamUrl);
+  const proxyReq = lib.request(
+    {
+      protocol: upstreamUrl.protocol,
+      hostname: upstreamUrl.hostname,
+      port: upstreamUrl.port,
+      path: fullPath,
+      method: req.method,
+      headers,
+      rejectUnauthorized: false
+    },
+    (proxyRes) => {
+      res.writeHead(proxyRes.statusCode || 502, proxyRes.headers as any);
+      proxyRes.pipe(res);
+    }
+  );
+
+  proxyReq.on("error", (err) => {
+    logger.warn(`[daemon-socket-proxy] HTTP error daemon=${parsed.daemonId}: ${err.message}`);
+    if (!res.headersSent) {
+      res.writeHead(502);
+      res.end("Bad gateway");
+    }
+  });
+
+  req.pipe(proxyReq);
+};
+
+/**
+ * Attach WebSocket upgrade proxy for Socket.IO.
+ * Call once with the panel HTTP(S) server after createServer.
+ */
+export function attachDaemonSocketUpgrade(server: http.Server | https.Server) {
+  server.on("upgrade", (req, socket: Duplex, head: Buffer) => {
+    const rawUrl = stripPanelPrefix(req.url || "");
+    if (!isDaemonSocketProxyUrl(rawUrl)) {
+      // Let other handlers (if any) process; if none, socket stays open until timeout
+      return;
+    }
+
+    // Cookie-based session is not easily available here without re-running session.
+    // We rely on: (1) same-origin only, (2) stream passport on daemon after connect.
+    // Still require a session cookie presence as a soft gate.
+    const cookie = req.headers.cookie || "";
+    if (!cookie) {
+      socket.write("HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n");
+      socket.destroy();
+      return;
+    }
+
+    let pathname = "";
+    try {
+      pathname = new URL(rawUrl, "http://localhost").pathname;
+    } catch {
+      socket.destroy();
+      return;
+    }
+
+    const parsed = parseDaemonSocketProxyPath(pathname);
+    if (!parsed) {
+      socket.destroy();
+      return;
+    }
+
+    const remote = RemoteServiceSubsystem.getInstance(parsed.daemonId);
+    if (!remote) {
+      socket.write("HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n");
+      socket.destroy();
+      return;
+    }
+
+    const daemonSocketPath = getDaemonSocketIoPath(remote);
+    const rewritten = rewriteSocketIoPath(rawUrl, daemonSocketPath);
+    const base = getDaemonHttpOrigin(remote);
+    const upstreamUrl = new URL(base);
+
+    const headers = filterRequestHeaders(req.headers);
+    headers["host"] = upstreamUrl.host;
+    // Ensure upgrade headers are present
+    if (req.headers.upgrade) headers["upgrade"] = req.headers.upgrade;
+    if (req.headers.connection) headers["connection"] = req.headers.connection;
+    if (req.headers["sec-websocket-key"])
+      headers["sec-websocket-key"] = req.headers["sec-websocket-key"];
+    if (req.headers["sec-websocket-version"])
+      headers["sec-websocket-version"] = req.headers["sec-websocket-version"];
+    if (req.headers["sec-websocket-extensions"])
+      headers["sec-websocket-extensions"] = req.headers["sec-websocket-extensions"];
+    if (req.headers["sec-websocket-protocol"])
+      headers["sec-websocket-protocol"] = req.headers["sec-websocket-protocol"];
+
+    const lib = pickHttpModule(upstreamUrl);
+    const proxyReq = lib.request({
+      protocol: upstreamUrl.protocol,
+      hostname: upstreamUrl.hostname,
+      port: upstreamUrl.port,
+      path: rewritten.path + rewritten.search,
+      method: "GET",
+      headers,
+      rejectUnauthorized: false
+    });
+
+    proxyReq.on("upgrade", (proxyRes, proxySocket: NetSocket, proxyHead: Buffer) => {
+      const responseHeaders = Object.entries(proxyRes.headers)
+        .filter(([, v]) => v != null)
+        .map(([k, v]) => `${k}: ${Array.isArray(v) ? v.join(", ") : v}`)
+        .join("\r\n");
+
+      socket.write(
+        `HTTP/1.1 101 Switching Protocols\r\n${responseHeaders}\r\n\r\n`
+      );
+      if (proxyHead && proxyHead.length) socket.write(proxyHead);
+      if (head && head.length) proxySocket.write(head);
+
+      proxySocket.pipe(socket);
+      socket.pipe(proxySocket);
+
+      const cleanup = () => {
+        proxySocket.destroy();
+        socket.destroy();
+      };
+      proxySocket.on("error", cleanup);
+      socket.on("error", cleanup);
+      proxySocket.on("close", () => socket.destroy());
+      socket.on("close", () => proxySocket.destroy());
+    });
+
+    proxyReq.on("error", (err) => {
+      logger.warn(
+        `[daemon-socket-proxy] upgrade error daemon=${parsed.daemonId}: ${err.message}`
+      );
+      socket.destroy();
+    });
+
+    proxyReq.end();
+  });
+}


### PR DESCRIPTION
Allow browsers to reach terminals and file transfer via the panel only, with a configurable proxy/direct dataPlaneMode for legacy direct-to-node access.