### PR TITLE
Ko_KR translation error correction

### DIFF
--- a/languages/ko_KR.json
+++ b/languages/ko_KR.json
@@ -2608,7 +2608,7 @@
   "TXT_CODE_d4c8fb3b": "관련 문서:",
   "TXT_CODE_d4cf1cb8": "아카이브",
   "TXT_CODE_d4dafc41": "Shulker 상자가 파괴되었을 때 내용물을 떨어 뜨려야하는지 여부",
-  "TXT_CODE_d507abff": "로그인",
+  "TXT_CODE_d507abff": "확인",
   "TXT_CODE_d51cd7ae": "생성하기",
   "TXT_CODE_d51db65a": "권한 이름",
   "TXT_CODE_d51f5d6": "두 번 입력한 비밀번호가 일치하지 않습니다.",


### PR DESCRIPTION
<img width="357" height="660" alt="image" src="https://github.com/user-attachments/assets/1679a3bc-b22c-4492-87e2-83a4185522b6" />

Changed 로그인(login) to 확인(confirm)