### PR TITLE
fix(daemon): skip disk quota scan for instances without maxSpace configured

### DIFF
--- a/daemon/src/entity/commands/task/any_stats.ts
+++ b/daemon/src/entity/commands/task/any_stats.ts
@@ -2,9 +2,9 @@ import disk_limit_service from "../../../service/disk_limit_service";
 import Instance from "../../instance/instance";
 import { ILifeCycleTask } from "../../instance/life_cycle";
 
-// Disk quota is opt-in: only instances with maxSpace > 0 are checked.
-// This mirrors the guard in start.ts and avoids a useless recursive `du`
-// scan on the working directory every 45s for instances that have no quota.
+// Disk quota is opt-in: maxSpace <= 0 (default 0 / unset / negative) means
+// the feature is disabled, so we skip the recursive `du` scan on the working
+// directory that would otherwise run every 45s for instances with no quota.
 const CHECK_INTERVAL_MS = 1000 * 45;
 
 export default class InstanceDiskCheckTask implements ILifeCycleTask {
@@ -15,7 +15,10 @@ export default class InstanceDiskCheckTask implements ILifeCycleTask {
 
   async start(instance: Instance) {
     this.task = setInterval(() => {
-      if (Number(instance.config.docker?.maxSpace) > 0) {
+      // maxSpace <= 0 means the quota feature is disabled (default/unset/negative).
+      // Treat it as off and skip the `du` scan, avoiding useless disk I/O.
+      const maxSpace = Number(instance.config.docker?.maxSpace);
+      if (maxSpace > 0) {
         disk_limit_service.checkInstanceDiskSize(instance);
       }
     }, CHECK_INTERVAL_MS);

--- a/daemon/src/entity/commands/task/any_stats.ts
+++ b/daemon/src/entity/commands/task/any_stats.ts
@@ -2,6 +2,11 @@ import disk_limit_service from "../../../service/disk_limit_service";
 import Instance from "../../instance/instance";
 import { ILifeCycleTask } from "../../instance/life_cycle";
 
+// Disk quota is opt-in: only instances with maxSpace > 0 are checked.
+// This mirrors the guard in start.ts and avoids a useless recursive `du`
+// scan on the working directory every 45s for instances that have no quota.
+const CHECK_INTERVAL_MS = 1000 * 45;
+
 export default class InstanceDiskCheckTask implements ILifeCycleTask {
   public status: number = 0;
   public name: string = "AnyInstanceStats";
@@ -10,8 +15,10 @@ export default class InstanceDiskCheckTask implements ILifeCycleTask {
 
   async start(instance: Instance) {
     this.task = setInterval(() => {
-      disk_limit_service.checkInstanceDiskSize(instance);
-    }, 1000 * 45);
+      if (Number(instance.config.docker?.maxSpace) > 0) {
+        disk_limit_service.checkInstanceDiskSize(instance);
+      }
+    }, CHECK_INTERVAL_MS);
   }
 
   async stop(instance: Instance) {

--- a/daemon/src/service/disk_limit_service.ts
+++ b/daemon/src/service/disk_limit_service.ts
@@ -30,8 +30,12 @@ class DiskLimitService {
   }
 
   async checkInstanceDiskSize(instance: Instance) {
-    const workspace = instance.absoluteCwdPath();
     const maxSpace = Number(instance.config.docker.maxSpace);
+    // Defensive guard: skip instances without a configured quota (maxSpace <= 0).
+    // The 45s lifecycle task already filters them, but this keeps the service
+    // contract self-contained so other callers cannot enqueue useless `du` jobs.
+    if (!(maxSpace > 0)) return;
+    const workspace = instance.absoluteCwdPath();
     this.queue.push({
       key: instance.instanceUuid,
       item: {

--- a/daemon/src/service/disk_limit_service.ts
+++ b/daemon/src/service/disk_limit_service.ts
@@ -31,10 +31,11 @@ class DiskLimitService {
 
   async checkInstanceDiskSize(instance: Instance) {
     const maxSpace = Number(instance.config.docker.maxSpace);
-    // Defensive guard: skip instances without a configured quota (maxSpace <= 0).
-    // The 45s lifecycle task already filters them, but this keeps the service
-    // contract self-contained so other callers cannot enqueue useless `du` jobs.
-    if (!(maxSpace > 0)) return;
+    // Defensive guard: maxSpace <= 0 means the quota feature is disabled
+    // (default 0 / unset / negative). The 45s lifecycle task already filters
+    // these out, but this keeps the service contract self-contained so other
+    // callers cannot enqueue useless `du` jobs.
+    if (maxSpace <= 0) return;
     const workspace = instance.absoluteCwdPath();
     this.queue.push({
       key: instance.instanceUuid,

--- a/daemon/src/utils/queue.ts
+++ b/daemon/src/utils/queue.ts
@@ -12,8 +12,14 @@ export class ConsumerQueue<T> {
     if (this.items.length >= this.maxSize) {
       this.items.shift();
     }
-    this.items.find((v) => v.key === item.key);
-    this.items.push(item);
+    // Deduplicate by key: if a pending item for this key exists, replace it
+    // instead of stacking a stale duplicate that would trigger redundant work.
+    const existingIndex = this.items.findIndex((v) => v.key === item.key);
+    if (existingIndex !== -1) {
+      this.items[existingIndex] = item;
+    } else {
+      this.items.push(item);
+    }
   }
 
   pop() {


### PR DESCRIPTION
## Fix Issue

https://github.com/MCSManager/MCSManager/issues/2274

The instance disk quota check timer (`any_stats.ts`, triggered every 45 seconds) unconditionally calls `checkInstanceDiskSize()`, executing `du -s` recursive scans on the working directories of **all** instances.

However, the default value of `maxSpace` is `0` (indicating no quota is configured), which means a large number of instances without configured quotas perform completely meaningless disk I/O every 45 seconds.

## Root Cause

1. **`any_stats.ts`**: The timer lacks a check for `maxSpace`. Note that the startup check in `start.ts` already has a `maxSpace > 0` guard; only this periodic task missed it, causing the issue to persist continuously during runtime.

2. **`disk_limit_service.ts`**: `checkInstanceDiskSize()` does not validate `maxSpace` before enqueuing, allowing any caller to push invalid tasks into the queue.

3. **`queue.ts`**: `push()` uses `find()` for deduplication but discards the result. Duplicate tasks are not deduplicated but keep stacking up, further amplifying the invalid scans.

## Changes

- `any_stats.ts`: Add `maxSpace > 0` guard at the timer entry
- `disk_limit_service.ts`: Add the same validation before enqueuing
- `queue.ts`: Fix `push()` deduplication logic; replace in-place upon hit instead of stacking