### PR TITLE
Fix: #2234

### DIFF
--- a/frontend/src/services/apis/index.ts
+++ b/frontend/src/services/apis/index.ts
@@ -278,6 +278,11 @@ export const ssoConfig = useDefineApi<any, SsoPublicConfig | null>({
   method: "GET"
 });
 
+export const ssoBindStatus = useDefineApi<any, { pending: boolean } | null>({
+  url: "/api/auth/sso/bind-status",
+  method: "GET"
+});
+
 export const ssoBindLogin = useDefineApi<
   {
     data: {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -102,6 +102,7 @@ export interface Settings {
   ssoIssuer: string;
   ssoClientId: string;
   ssoClientSecret: string;
+  ssoTokenAuthMethod: string;
   ssoCallbackUrl: string;
   operationLogEnabled: boolean;
   operationLogMaxLinesPerFile: number;

--- a/frontend/src/views/SsoBindLogin.vue
+++ b/frontend/src/views/SsoBindLogin.vue
@@ -2,7 +2,7 @@
 import CardPanel from "@/components/CardPanel.vue";
 import { router } from "@/config/router";
 import { t } from "@/lang/i18n";
-import { ssoBindCurrent, ssoBindLogin, userInfoApi } from "@/services/apis";
+import { ssoBindCurrent, ssoBindLogin, ssoBindStatus, userInfoApi } from "@/services/apis";
 import { useAppStateStore } from "@/stores/useAppStateStore";
 import { sleep } from "@/tools/common";
 import { reportErrorMsg } from "@/tools/validator";
@@ -19,6 +19,7 @@ import { onMounted, reactive, ref } from "vue";
 const { updateUserInfo, isAdmin } = useAppStateStore();
 const { execute: bindExecute } = ssoBindLogin();
 const { execute: bindCurrentExecute } = ssoBindCurrent();
+const { execute: fetchBindStatus } = ssoBindStatus();
 const { execute: fetchUserInfo } = userInfoApi();
 
 const formData = reactive({
@@ -27,12 +28,20 @@ const formData = reactive({
   code: ""
 });
 
-const step = ref(0);
+const step = ref(1);
 const is2Fa = ref(false);
 const loggedInUserName = ref("");
 const showLoginForm = ref(false);
 
 onMounted(async () => {
+  try {
+    const status = await fetchBindStatus();
+    if (!status.value?.pending) throw new Error("no pending SSO binding");
+  } catch {
+    router.replace({ path: "/login", query: { sso_error: "invalid_sso_session" } });
+    return;
+  }
+
   try {
     const info = await fetchUserInfo();
     if (info.value?.userName) {
@@ -41,6 +50,8 @@ onMounted(async () => {
   } catch {
     // Not logged in
   }
+
+  step.value = 0;
 });
 
 const handleBindCurrent = async () => {
@@ -115,7 +126,7 @@ const handleBind = async () => {
           <div v-if="loggedInUserName && !showLoginForm">
             <a-alert type="info" show-icon class="mb-20">
               <template #message>
-                {{ t('TXT_CODE_SSO_BIND_CURRENT_HINT') }}
+                {{ t("TXT_CODE_SSO_BIND_CURRENT_HINT") }}
                 <strong>{{ loggedInUserName }}</strong>
               </template>
             </a-alert>
@@ -197,9 +208,7 @@ const handleBind = async () => {
 
         <div v-show="step >= 2" class="sso-bind-body flex-center">
           <div style="text-align: center">
-            <CheckCircleOutlined
-              :style="{ fontSize: '62px', color: 'var(--color-green-6)' }"
-            />
+            <CheckCircleOutlined :style="{ fontSize: '62px', color: 'var(--color-green-6)' }" />
           </div>
         </div>
       </template>

--- a/frontend/src/widgets/Settings.vue
+++ b/frontend/src/widgets/Settings.vue
@@ -369,7 +369,7 @@ const doSubmitSso = async () => {
 const submitSso = async () => {
   const fd = formData.value as any;
   if (fd?.ssoEnabled) {
-    if (!fd.ssoClientId?.trim() || !fd.ssoClientSecret?.trim()) {
+    if (!fd.ssoClientId?.trim()) {
       return message.error(t("TXT_CODE_SSO_ENABLE_REQUIRES_CONFIG"));
     }
     if (fd.ssoType === "oauth2") {
@@ -1267,7 +1267,7 @@ onUnmounted(() => {
                       <a-input-password
                         v-model:value="(formData as any).ssoClientSecret"
                         style="max-width: 480px"
-                        :placeholder="t('TXT_CODE_4ea93630')"
+                        :placeholder="t('留空表示不修改')"
                       />
                     </a-form-item>
 

--- a/frontend/src/widgets/Settings.vue
+++ b/frontend/src/widgets/Settings.vue
@@ -1273,6 +1273,27 @@ onUnmounted(() => {
 
                     <a-form-item>
                       <a-typography-title :level="5">
+                        {{ t("Token 端点认证方式") }}
+                      </a-typography-title>
+                      <a-typography-paragraph type="secondary">
+                        {{ t("向 Token 端点提交 client_id / client_secret 的方式。") }}
+                      </a-typography-paragraph>
+                      <a-select
+                        v-model:value="(formData as any).ssoTokenAuthMethod"
+                        style="max-width: 320px"
+                      >
+                        <a-select-option value="auto">{{ t("自动") }}</a-select-option>
+                        <a-select-option value="client_secret_basic">
+                          client_secret_basic
+                        </a-select-option>
+                        <a-select-option value="client_secret_post">
+                          client_secret_post
+                        </a-select-option>
+                      </a-select>
+                    </a-form-item>
+
+                    <a-form-item>
+                      <a-typography-title :level="5">
                         {{ t("TXT_CODE_SSO_CALLBACK_URL") }}
                       </a-typography-title>
                       <a-typography-paragraph type="secondary">

--- a/panel/src/app/common/config_diff.ts
+++ b/panel/src/app/common/config_diff.ts
@@ -1,5 +1,5 @@
 const SENSITIVE_KEY_REGEX = /passw(or)?d|secret|token|api_?key/i;
-const MASK_TEXT = "******";
+export const MASK_TEXT = "******";
 
 const DIFF_EXCLUDED_KEY_REGEX = /^(passw(or)?d|passWordType|salt|secret|api_?key)$/i;
 

--- a/panel/src/app/common/config_diff.ts
+++ b/panel/src/app/common/config_diff.ts
@@ -1,5 +1,5 @@
 const SENSITIVE_KEY_REGEX = /passw(or)?d|secret|token|api_?key/i;
-export const MASK_TEXT = "******";
+const MASK_TEXT = "******";
 
 const DIFF_EXCLUDED_KEY_REGEX = /^(passw(or)?d|passWordType|salt|secret|api_?key)$/i;
 

--- a/panel/src/app/entity/setting.ts
+++ b/panel/src/app/entity/setting.ts
@@ -108,6 +108,7 @@ export default class SystemConfig {
   // Shared
   ssoClientId = "";
   ssoClientSecret = "";
+  ssoTokenAuthMethod: "auto" | "client_secret_basic" | "client_secret_post" = "auto";
   ssoCallbackUrl = "";
 
   // Whether to enable SSL/TLS (HTTPS)

--- a/panel/src/app/routers/settings_router.ts
+++ b/panel/src/app/routers/settings_router.ts
@@ -137,8 +137,8 @@ router.put("/setting", permission({ level: ROLE.ADMIN }), async (ctx) => {
 
       if (ssoType === "oidc") {
         const issuer = config.ssoIssuer != null ? String(config.ssoIssuer) : systemConfig.ssoIssuer;
-        if (issuer && !issuer.startsWith("https://") && !issuer.startsWith("http://")) {
-          throw new Error("SSO Issuer URL must use http(s) protocol");
+        if (issuer && !issuer.startsWith("https://")) {
+          throw new Error("SSO Issuer URL must use the https protocol");
         }
         if (wantEnable && (!issuer?.trim() || !clientId?.trim() || !clientSecret?.trim())) {
           throw new Error(

--- a/panel/src/app/routers/settings_router.ts
+++ b/panel/src/app/routers/settings_router.ts
@@ -4,7 +4,7 @@ import * as fs from "fs-extra";
 import path from "path";
 import { v4 } from "uuid";
 import FileManager from "../../../../daemon/src/service/system_file";
-import { diffConfig } from "../common/config_diff";
+import { diffConfig, MASK_TEXT } from "../common/config_diff";
 import { MARKET_CACHE_FILE_PATH, SAVE_DIR_PATH } from "../const";
 import SystemConfig from "../entity/setting";
 import { ROLE } from "../entity/user";
@@ -28,7 +28,14 @@ const router = new Router({ prefix: "/overview" });
 // [Top-level Permission]
 // Get panel configuration items
 router.get("/setting", permission({ level: ROLE.ADMIN }), async (ctx) => {
-  ctx.body = systemConfig;
+  if (!systemConfig) {
+    ctx.body = systemConfig;
+    return;
+  }
+  ctx.body = {
+    ...systemConfig,
+    ssoClientSecret: systemConfig.ssoClientSecret ? MASK_TEXT : ""
+  };
 });
 
 // [Top-level Permission]
@@ -131,7 +138,7 @@ router.put("/setting", permission({ level: ROLE.ADMIN }), async (ctx) => {
       const clientId =
         config.ssoClientId != null ? String(config.ssoClientId) : systemConfig.ssoClientId;
       const clientSecret =
-        config.ssoClientSecret != null
+        config.ssoClientSecret != null && config.ssoClientSecret !== MASK_TEXT
           ? String(config.ssoClientSecret)
           : systemConfig.ssoClientSecret;
 

--- a/panel/src/app/routers/settings_router.ts
+++ b/panel/src/app/routers/settings_router.ts
@@ -140,8 +140,8 @@ router.put("/setting", permission({ level: ROLE.ADMIN }), async (ctx) => {
 
       if (ssoType === "oidc") {
         const issuer = config.ssoIssuer != null ? String(config.ssoIssuer) : systemConfig.ssoIssuer;
-        if (issuer && !issuer.startsWith("https://") && !issuer.startsWith("http://")) {
-          throw new Error("SSO Issuer URL must use http(s) protocol");
+        if (issuer && !issuer.startsWith("https://")) {
+          throw new Error("SSO Issuer URL must use the https protocol");
         }
         if (wantEnable && (!issuer?.trim() || !clientId?.trim() || !clientSecret?.trim())) {
           throw new Error(

--- a/panel/src/app/routers/settings_router.ts
+++ b/panel/src/app/routers/settings_router.ts
@@ -113,6 +113,17 @@ router.put("/setting", permission({ level: ROLE.ADMIN }), async (ctx) => {
     }
     const ssoType = systemConfig.ssoType || "oidc";
 
+    // SSO Token Endpoint client authentication method
+    if (config.ssoTokenAuthMethod != null) {
+      const m = String(config.ssoTokenAuthMethod);
+      if (m !== "auto" && m !== "client_secret_basic" && m !== "client_secret_post") {
+        throw new Error(
+          "ssoTokenAuthMethod must be 'auto', 'client_secret_basic' or 'client_secret_post'"
+        );
+      }
+      systemConfig.ssoTokenAuthMethod = m;
+    }
+
     // SSO core fields
     {
       const wantEnable =

--- a/panel/src/app/routers/settings_router.ts
+++ b/panel/src/app/routers/settings_router.ts
@@ -4,7 +4,7 @@ import * as fs from "fs-extra";
 import path from "path";
 import { v4 } from "uuid";
 import FileManager from "../../../../daemon/src/service/system_file";
-import { diffConfig, MASK_TEXT } from "../common/config_diff";
+import { diffConfig } from "../common/config_diff";
 import { MARKET_CACHE_FILE_PATH, SAVE_DIR_PATH } from "../const";
 import SystemConfig from "../entity/setting";
 import { ROLE } from "../entity/user";
@@ -32,10 +32,7 @@ router.get("/setting", permission({ level: ROLE.ADMIN }), async (ctx) => {
     ctx.body = systemConfig;
     return;
   }
-  ctx.body = {
-    ...systemConfig,
-    ssoClientSecret: systemConfig.ssoClientSecret ? MASK_TEXT : ""
-  };
+  ctx.body = { ...systemConfig, ssoClientSecret: "" };
 });
 
 // [Top-level Permission]
@@ -137,10 +134,9 @@ router.put("/setting", permission({ level: ROLE.ADMIN }), async (ctx) => {
         config.ssoEnabled != null ? Boolean(config.ssoEnabled) : systemConfig.ssoEnabled;
       const clientId =
         config.ssoClientId != null ? String(config.ssoClientId) : systemConfig.ssoClientId;
-      const clientSecret =
-        config.ssoClientSecret != null && config.ssoClientSecret !== MASK_TEXT
-          ? String(config.ssoClientSecret)
-          : systemConfig.ssoClientSecret;
+      const clientSecret = config.ssoClientSecret
+        ? String(config.ssoClientSecret)
+        : systemConfig.ssoClientSecret;
 
       if (ssoType === "oidc") {
         const issuer = config.ssoIssuer != null ? String(config.ssoIssuer) : systemConfig.ssoIssuer;
@@ -207,7 +203,7 @@ router.put("/setting", permission({ level: ROLE.ADMIN }), async (ctx) => {
 
       if (config.ssoEnabled != null) systemConfig.ssoEnabled = wantEnable;
       if (config.ssoClientId != null) systemConfig.ssoClientId = clientId;
-      if (config.ssoClientSecret != null) systemConfig.ssoClientSecret = clientSecret;
+      if (config.ssoClientSecret) systemConfig.ssoClientSecret = clientSecret;
     }
 
     if (config.ssoUserIdField != null)

--- a/panel/src/app/routers/settings_router.ts
+++ b/panel/src/app/routers/settings_router.ts
@@ -144,8 +144,8 @@ router.put("/setting", permission({ level: ROLE.ADMIN }), async (ctx) => {
 
       if (ssoType === "oidc") {
         const issuer = config.ssoIssuer != null ? String(config.ssoIssuer) : systemConfig.ssoIssuer;
-        if (issuer && !issuer.startsWith("https://")) {
-          throw new Error("SSO Issuer URL must use the https protocol");
+        if (issuer && !issuer.startsWith("https://") && !issuer.startsWith("http://")) {
+          throw new Error("SSO Issuer URL must use http(s) protocol");
         }
         if (wantEnable && (!issuer?.trim() || !clientId?.trim() || !clientSecret?.trim())) {
           throw new Error(

--- a/panel/src/app/routers/settings_router.ts
+++ b/panel/src/app/routers/settings_router.ts
@@ -145,10 +145,17 @@ router.put("/setting", permission({ level: ROLE.ADMIN }), async (ctx) => {
             "Cannot enable SSO (OIDC): Issuer, Client ID, and Client Secret are required"
           );
         }
-        if (issuer?.trim() && clientId?.trim() && clientSecret?.trim()) {
-          const { verifyIssuer, clearOIDCCache } = require("../service/sso_service");
+        const oidcCredentialsChanged =
+          issuer !== systemConfig.ssoIssuer ||
+          clientId !== systemConfig.ssoClientId ||
+          clientSecret !== systemConfig.ssoClientSecret;
+        const needVerify =
+          wantEnable &&
+          Boolean(issuer?.trim() && clientId?.trim() && clientSecret?.trim()) &&
+          (!systemConfig.ssoEnabled || oidcCredentialsChanged);
+        if (needVerify) {
+          const { verifyIssuer } = require("../service/sso_service");
           await verifyIssuer(issuer, clientId, clientSecret);
-          clearOIDCCache();
         }
         if (config.ssoIssuer != null) systemConfig.ssoIssuer = issuer;
       } else {

--- a/panel/src/app/routers/sso_router.ts
+++ b/panel/src/app/routers/sso_router.ts
@@ -14,13 +14,23 @@ import {
   generateState,
   getCallbackUrl,
   getPublicSsoConfig,
-  handleOIDCCallback,
-  handleOAuth2Callback
+  handleOAuth2Callback,
+  handleOIDCCallback
 } from "../service/sso_service";
 import userSystem, { TwoFactorError } from "../service/user_service";
 import { systemConfig } from "../setting";
 
 const router = new Router({ prefix: "/auth/sso" });
+
+const SSO_BIND_SESSION_TTL = 10 * 60 * 1000;
+
+function hasPendingSsoBind(ctx: Koa.ParameterizedContext): boolean {
+  const ssoSub = ctx.session?.["ssoBindSub"];
+  const ssoBindTimestamp = ctx.session?.["ssoBindTimestamp"];
+  if (!ssoSub || !ssoBindTimestamp) return false;
+  if (Date.now() - ssoBindTimestamp > SSO_BIND_SESSION_TTL) return false;
+  return !userSystem.getUserBySsoSub(ssoSub);
+}
 
 // [Public] Return SSO configuration (no secrets)
 router.get(
@@ -129,19 +139,18 @@ router.get(
 
     try {
       let sub: string;
-      let claims: Record<string, unknown>;
 
       if (isOAuth2) {
         const code = callbackUrl.searchParams.get("code");
         if (!code) throw new Error("OAuth 2.0 callback missing code parameter");
         const stateParam = callbackUrl.searchParams.get("state");
         if (stateParam !== expectedState) throw new Error("OAuth 2.0 state mismatch");
-        ({ sub, claims } = await handleOAuth2Callback(code, codeVerifier, ctx));
+        ({ sub } = await handleOAuth2Callback(code, codeVerifier, ctx));
       } else {
         const configuredCallback = getCallbackUrl(ctx);
         const reconstructedUrl = new URL(configuredCallback);
         reconstructedUrl.search = callbackUrl.search;
-        ({ sub, claims } = await handleOIDCCallback(
+        ({ sub } = await handleOIDCCallback(
           reconstructedUrl,
           expectedState,
           expectedNonce,
@@ -167,7 +176,6 @@ router.get(
 
       // Not bound yet - redirect to bind page
       ctx.session!["ssoBindSub"] = sub;
-      ctx.session!["ssoBindClaims"] = JSON.stringify(claims);
       ctx.session!["ssoBindTimestamp"] = Date.now();
       ctx.session!.save();
 
@@ -183,6 +191,14 @@ router.get(
       });
       ctx.redirect(`/#/login?${params.toString()}`);
     }
+  }
+);
+
+router.get(
+  "/bind-status",
+  permission({ token: false, level: null, speedLimit: false }),
+  async (ctx: Koa.ParameterizedContext) => {
+    ctx.body = { pending: Boolean(systemConfig?.ssoEnabled) && hasPendingSsoBind(ctx) };
   }
 );
 
@@ -210,9 +226,8 @@ router.post(
     }
 
     // Reject if the bind session is older than 10 minutes
-    if (!ssoBindTimestamp || Date.now() - ssoBindTimestamp > 10 * 60 * 1000) {
+    if (!ssoBindTimestamp || Date.now() - ssoBindTimestamp > SSO_BIND_SESSION_TTL) {
       delete ctx.session["ssoBindSub"];
-      delete ctx.session["ssoBindClaims"];
       delete ctx.session["ssoBindTimestamp"];
       ctx.session.save();
       throw new Error("SSO binding session expired");
@@ -222,7 +237,6 @@ router.post(
     const alreadyBound = userSystem.getUserBySsoSub(ssoSub);
     if (alreadyBound) {
       delete ctx.session["ssoBindSub"];
-      delete ctx.session["ssoBindClaims"];
       delete ctx.session["ssoBindTimestamp"];
       ctx.session.save();
       throw new Error("This SSO account is already bound to another user");
@@ -254,7 +268,6 @@ router.post(
 
     // Clean up session
     delete ctx.session["ssoBindSub"];
-    delete ctx.session["ssoBindClaims"];
     delete ctx.session["ssoBindTimestamp"];
 
     const token = loginSuccess(ctx, userName);
@@ -291,9 +304,8 @@ router.post(
       throw new Error("No pending SSO binding session");
     }
 
-    if (!ssoBindTimestamp || Date.now() - ssoBindTimestamp > 10 * 60 * 1000) {
+    if (!ssoBindTimestamp || Date.now() - ssoBindTimestamp > SSO_BIND_SESSION_TTL) {
       delete ctx.session["ssoBindSub"];
-      delete ctx.session["ssoBindClaims"];
       delete ctx.session["ssoBindTimestamp"];
       ctx.session.save();
       throw new Error("SSO binding session expired");
@@ -302,7 +314,6 @@ router.post(
     const alreadyBound = userSystem.getUserBySsoSub(ssoSub);
     if (alreadyBound) {
       delete ctx.session["ssoBindSub"];
-      delete ctx.session["ssoBindClaims"];
       delete ctx.session["ssoBindTimestamp"];
       ctx.session.save();
       throw new Error("This SSO account is already bound to another user");
@@ -321,7 +332,6 @@ router.post(
     await userSystem.bindSso(user.uuid, ssoSub);
 
     delete ctx.session["ssoBindSub"];
-    delete ctx.session["ssoBindClaims"];
     delete ctx.session["ssoBindTimestamp"];
     ctx.session.save();
 

--- a/panel/src/app/service/sso_service.ts
+++ b/panel/src/app/service/sso_service.ts
@@ -4,6 +4,34 @@ import { systemConfig } from "../setting";
 import { logger } from "./log";
 import crypto from "crypto";
 
+// ─── Token Endpoint client authentication ───
+
+const SSO_TOKEN_AUTH_METHODS = ["auto", "client_secret_basic", "client_secret_post"] as const;
+type SsoTokenAuthMethod = (typeof SSO_TOKEN_AUTH_METHODS)[number];
+
+function getTokenAuthMethod(): SsoTokenAuthMethod {
+  const method = systemConfig?.ssoTokenAuthMethod as SsoTokenAuthMethod;
+  return SSO_TOKEN_AUTH_METHODS.includes(method) ? method : "auto";
+}
+
+// Delegating ClientAuth: the method is resolved on every token request, so a
+// config change takes effect immediately without rebuilding the cached Configuration.
+function buildClientAuth(): oidc.ClientAuth {
+  const basic = oidc.ClientSecretBasic();
+  const post = oidc.ClientSecretPost();
+  return (as, client, body, headers) => {
+    const method = getTokenAuthMethod();
+    const useBasic =
+      method === "client_secret_basic"
+        ? true
+        : method === "client_secret_post"
+          ? false
+          : // auto: follow the discovery document, keep posting when it says nothing
+            as.token_endpoint_auth_methods_supported?.includes("client_secret_basic") === true;
+    (useBasic ? basic : post)(as, client, body, headers);
+  };
+}
+
 // ─── OIDC Cache ───
 
 let cachedConfig: oidc.Configuration | null = null;
@@ -22,9 +50,16 @@ export async function getOIDCConfig(): Promise<oidc.Configuration> {
 
   try {
     const issuerUrl = new URL(systemConfig.ssoIssuer);
-    cachedConfig = await oidc.discovery(issuerUrl, systemConfig.ssoClientId, systemConfig.ssoClientSecret);
+    cachedConfig = await oidc.discovery(
+      issuerUrl,
+      systemConfig.ssoClientId,
+      systemConfig.ssoClientSecret,
+      buildClientAuth()
+    );
     cachedIssuer = systemConfig.ssoIssuer;
-    logger.info("[SSO] OIDC discovery completed for: " + systemConfig.ssoIssuer);
+    logger.info(
+      `[SSO] OIDC discovery completed for: ${systemConfig.ssoIssuer} (token endpoint auth: ${getTokenAuthMethod()})`
+    );
     return cachedConfig;
   } catch (err: any) {
     cachedConfig = null;
@@ -42,7 +77,7 @@ export function clearOIDCCache() {
 export async function verifyIssuer(issuer: string, clientId: string, clientSecret: string): Promise<void> {
   try {
     const issuerUrl = new URL(issuer);
-    await oidc.discovery(issuerUrl, clientId, clientSecret);
+    await oidc.discovery(issuerUrl, clientId, clientSecret, buildClientAuth());
   } catch (err: any) {
     logger.error("[SSO] Issuer verification failed: " + err.message);
     throw new Error(`SSO Issuer verification failed: unable to reach ${issuer}/.well-known/openid-configuration`);
@@ -149,17 +184,27 @@ async function oauth2TokenExchange(
     grant_type: "authorization_code",
     code,
     redirect_uri: redirectUri,
-    client_id: systemConfig.ssoClientId,
-    client_secret: systemConfig.ssoClientSecret,
     code_verifier: codeVerifier
   });
+  const headers: Record<string, string> = {
+    "Content-Type": "application/x-www-form-urlencoded",
+    Accept: "application/json"
+  };
+
+  // There is no discovery document in OAuth 2.0 mode, so "auto" keeps posting the credentials.
+  if (getTokenAuthMethod() === "client_secret_basic") {
+    const credentials = `${encodeURIComponent(systemConfig.ssoClientId)}:${encodeURIComponent(
+      systemConfig.ssoClientSecret
+    )}`;
+    headers.Authorization = `Basic ${Buffer.from(credentials).toString("base64")}`;
+  } else {
+    body.set("client_id", systemConfig.ssoClientId);
+    body.set("client_secret", systemConfig.ssoClientSecret);
+  }
 
   const res = await fetch(systemConfig.ssoTokenUrl, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      Accept: "application/json"
-    },
+    headers,
     body: body.toString()
   });
 

--- a/panel/src/app/service/sso_service.ts
+++ b/panel/src/app/service/sso_service.ts
@@ -37,14 +37,6 @@ function buildClientAuth(): oidc.ClientAuth {
 let cachedConfig: oidc.Configuration | null = null;
 let cachedConfigKey = "";
 
-function discoveryOptions(issuerUrl: URL): oidc.DiscoveryRequestOptions | undefined {
-  if (issuerUrl.protocol !== "http:") return undefined;
-  logger.warn(
-    `[SSO] Issuer ${issuerUrl.origin} uses plain HTTP; client credentials and tokens will be sent unencrypted.`
-  );
-  return { execute: [oidc.allowInsecureRequests] };
-}
-
 function oidcConfigKey(): string {
   return crypto
     .createHash("sha256")
@@ -72,8 +64,7 @@ export async function getOIDCConfig(): Promise<oidc.Configuration> {
       issuerUrl,
       systemConfig.ssoClientId,
       systemConfig.ssoClientSecret,
-      buildClientAuth(),
-      discoveryOptions(issuerUrl)
+      buildClientAuth()
     );
     cachedConfigKey = configKey;
     logger.info(
@@ -91,13 +82,7 @@ export async function getOIDCConfig(): Promise<oidc.Configuration> {
 export async function verifyIssuer(issuer: string, clientId: string, clientSecret: string): Promise<void> {
   try {
     const issuerUrl = new URL(issuer);
-    await oidc.discovery(
-      issuerUrl,
-      clientId,
-      clientSecret,
-      buildClientAuth(),
-      discoveryOptions(issuerUrl)
-    );
+    await oidc.discovery(issuerUrl, clientId, clientSecret, buildClientAuth());
   } catch (err: any) {
     logger.error("[SSO] Issuer verification failed: " + err.message);
     throw new Error(`SSO Issuer verification failed: unable to reach ${issuer}/.well-known/openid-configuration`);

--- a/panel/src/app/service/sso_service.ts
+++ b/panel/src/app/service/sso_service.ts
@@ -79,11 +79,6 @@ export async function getOIDCConfig(): Promise<oidc.Configuration> {
   }
 }
 
-export function clearOIDCCache() {
-  cachedConfig = null;
-  cachedConfigKey = "";
-}
-
 export async function verifyIssuer(issuer: string, clientId: string, clientSecret: string): Promise<void> {
   try {
     const issuerUrl = new URL(issuer);

--- a/panel/src/app/service/sso_service.ts
+++ b/panel/src/app/service/sso_service.ts
@@ -35,7 +35,16 @@ function buildClientAuth(): oidc.ClientAuth {
 // ─── OIDC Cache ───
 
 let cachedConfig: oidc.Configuration | null = null;
-let cachedIssuer = "";
+let cachedConfigKey = "";
+
+function oidcConfigKey(): string {
+  return crypto
+    .createHash("sha256")
+    .update(
+      [systemConfig?.ssoIssuer, systemConfig?.ssoClientId, systemConfig?.ssoClientSecret].join("\n")
+    )
+    .digest("hex");
+}
 
 export async function getOIDCConfig(): Promise<oidc.Configuration> {
   if (!systemConfig) throw new Error("System config not initialized");
@@ -44,7 +53,8 @@ export async function getOIDCConfig(): Promise<oidc.Configuration> {
     throw new Error("SSO configuration is incomplete");
   }
 
-  if (cachedConfig && cachedIssuer === systemConfig.ssoIssuer) {
+  const configKey = oidcConfigKey();
+  if (cachedConfig && cachedConfigKey === configKey) {
     return cachedConfig;
   }
 
@@ -56,14 +66,14 @@ export async function getOIDCConfig(): Promise<oidc.Configuration> {
       systemConfig.ssoClientSecret,
       buildClientAuth()
     );
-    cachedIssuer = systemConfig.ssoIssuer;
+    cachedConfigKey = configKey;
     logger.info(
       `[SSO] OIDC discovery completed for: ${systemConfig.ssoIssuer} (token endpoint auth: ${getTokenAuthMethod()})`
     );
     return cachedConfig;
   } catch (err: any) {
     cachedConfig = null;
-    cachedIssuer = "";
+    cachedConfigKey = "";
     logger.error("[SSO] OIDC discovery failed: " + err.message);
     throw new Error("OIDC discovery failed. Check server logs for details.");
   }
@@ -71,7 +81,7 @@ export async function getOIDCConfig(): Promise<oidc.Configuration> {
 
 export function clearOIDCCache() {
   cachedConfig = null;
-  cachedIssuer = "";
+  cachedConfigKey = "";
 }
 
 export async function verifyIssuer(issuer: string, clientId: string, clientSecret: string): Promise<void> {

--- a/panel/src/app/service/sso_service.ts
+++ b/panel/src/app/service/sso_service.ts
@@ -37,6 +37,14 @@ function buildClientAuth(): oidc.ClientAuth {
 let cachedConfig: oidc.Configuration | null = null;
 let cachedConfigKey = "";
 
+function discoveryOptions(issuerUrl: URL): oidc.DiscoveryRequestOptions | undefined {
+  if (issuerUrl.protocol !== "http:") return undefined;
+  logger.warn(
+    `[SSO] Issuer ${issuerUrl.origin} uses plain HTTP; client credentials and tokens will be sent unencrypted.`
+  );
+  return { execute: [oidc.allowInsecureRequests] };
+}
+
 function oidcConfigKey(): string {
   return crypto
     .createHash("sha256")
@@ -64,7 +72,8 @@ export async function getOIDCConfig(): Promise<oidc.Configuration> {
       issuerUrl,
       systemConfig.ssoClientId,
       systemConfig.ssoClientSecret,
-      buildClientAuth()
+      buildClientAuth(),
+      discoveryOptions(issuerUrl)
     );
     cachedConfigKey = configKey;
     logger.info(
@@ -82,7 +91,13 @@ export async function getOIDCConfig(): Promise<oidc.Configuration> {
 export async function verifyIssuer(issuer: string, clientId: string, clientSecret: string): Promise<void> {
   try {
     const issuerUrl = new URL(issuer);
-    await oidc.discovery(issuerUrl, clientId, clientSecret, buildClientAuth());
+    await oidc.discovery(
+      issuerUrl,
+      clientId,
+      clientSecret,
+      buildClientAuth(),
+      discoveryOptions(issuerUrl)
+    );
   } catch (err: any) {
     logger.error("[SSO] Issuer verification failed: " + err.message);
     throw new Error(`SSO Issuer verification failed: unable to reach ${issuer}/.well-known/openid-configuration`);


### PR DESCRIPTION
fixed #2234.

- 修复 Token Endpoint 认证方式不可配置的问题。
- 修复绑定页 Cookie 过长的问题。（OIDC 当前回调会把 ID Token claims 的所有内容写入 session，而 koa-session 没有服务端 Store，全部塞进 Cookie）这个字段在后续代码中从来没被读过，因此直接删除。另外加了 bind-status 接口，绑定页打开就先检查，避免用户填完表单才提示 No pending SSO binding session。
- 修复每次保存设置都连接 IdP 的问题。`verifyIssuer()`  改成只在启用且凭据有变化时验证。
- 去除 Client Secret 明文返回。
- OIDC 配置缓存键改为 issuer、client id、client secret 三者哈希。