### PR TITLE
fix: release upload lock for zero-byte files

### DIFF
--- a/daemon/src/entity/file_writer.ts
+++ b/daemon/src/entity/file_writer.ts
@@ -114,7 +114,10 @@ export default class FileWriter {
     if (this.fd != null) {
       await fs.close(this.fd);
       this.fd = null;
-      await this.releaseLock!();
+      if (typeof this.releaseLock === "function") {
+        await this.releaseLock();
+        this.releaseLock = undefined;
+      }
     }
 
     if (this.id != null) {
@@ -179,11 +182,20 @@ export default class FileWriter {
   }
 
   private isFullyCovered(): boolean {
+    // Zero-byte uploads never receive pieces; treat them as complete.
+    if (this.size === 0) return true;
     return (
       this.received.length === 1 &&
       this.received[0].start === 0 &&
       this.received[0].end === this.size
     );
+  }
+
+  /** Complete the upload when no further pieces are expected (e.g. empty files). */
+  async completeIfCovered() {
+    if (this.fd != null && this.isFullyCovered()) {
+      await this.done();
+    }
   }
 
   private readStreamToHash(

--- a/daemon/src/routers/http_router.ts
+++ b/daemon/src/routers/http_router.ts
@@ -179,6 +179,8 @@ router.post("/upload-new/:key", async (ctx) => {
       await fileWriter.init();
       const id = uploadManager.add(fileWriter);
       fr = { id, writer: fileWriter };
+      // Empty files never send upload pieces, so finish and release the lock here.
+      await fileWriter.completeIfCovered();
     }
 
     ctx.body = {


### PR DESCRIPTION
Zero-byte uploads never send pieces, so the daemon left the proper-lockfile lock directory behind after reporting success. Complete the writer right after init when the file size is already covered so the lock is released.

Fixes #2311