### PR TITLE
fix: 优化实例页面触摸屏设备手感和文件上传刷新

### DIFF
--- a/daemon/src/entity/file_writer.ts
+++ b/daemon/src/entity/file_writer.ts
@@ -2,6 +2,7 @@ import fs from "fs-extra";
 import path from "path";
 import * as lockfile from "proper-lockfile";
 import logger from "../service/log";
+import { $t } from "../i18n";
 import FileManager from "../service/system_file";
 import uploadManager from "../service/upload_manager";
 import { globalEnv } from "./config";
@@ -16,6 +17,10 @@ export default class FileWriter {
   private releaseLock?: () => Promise<void>;
   private fd: number | null = null;
   private completion?: Promise<void>;
+  private pendingWrites = new Set<Promise<void>>();
+  private stopPromise?: Promise<void>;
+  private stopping = false;
+  private ownsFile = false;
   readonly received: ChunkRange[] = [];
   lastUpdate: number = Date.now();
 
@@ -88,20 +93,60 @@ export default class FileWriter {
     }
     try {
       this.fd = await fs.open(this.path, "w+");
+      this.ownsFile = true;
       this.releaseLock = await lockfile.lock(this.path);
       await fs.ftruncate(this.fd, this.size);
     } catch (e) {
-      if (typeof this.releaseLock === "function") await this.releaseLock();
-      this.releaseLock = undefined;
+      try {
+        await this.stop();
+      } catch (cleanupError) {
+        logger.error("Error cleaning failed file upload initialization:", this.path, cleanupError);
+      }
       throw e;
     }
   }
 
   async write(offset: number, chunk: Buffer) {
+    if (this.stopping) throw new Error("File is not opened");
+    const operation = this.writeChunk(offset, chunk);
+    this.pendingWrites.add(operation);
+    operation.catch(() => {
+      this.stopping = true;
+    });
+    try {
+      await operation;
+    } catch (error) {
+      this.pendingWrites.delete(operation);
+      try {
+        await this.stop();
+      } catch (cleanupError) {
+        logger.error("Error cleaning failed file upload:", this.path, cleanupError);
+      }
+      throw error;
+    } finally {
+      this.pendingWrites.delete(operation);
+    }
+  }
+
+  private async writeChunk(offset: number, chunk: Buffer) {
     this.lastUpdate = Date.now();
     if (offset + chunk.length > this.size) throw new Error("Write exceeds file size limit");
-    if (this.fd === null) throw new Error("File is not opened");
-    await fs.write(this.fd, chunk, 0, chunk.length, offset);
+    if (this.stopping || this.fd === null) throw new Error("File is not opened");
+
+    let written = 0;
+    while (written < chunk.length) {
+      const result = await fs.write(
+        this.fd,
+        chunk,
+        written,
+        chunk.length - written,
+        offset + written
+      );
+      if (result.bytesWritten <= 0) {
+        throw new Error($t("TXT_CODE_http_router.updateErr"));
+      }
+      written += result.bytesWritten;
+    }
 
     this.addWrittenRange(offset, offset + chunk.length);
     if (this.isFullyCovered()) {
@@ -162,16 +207,48 @@ export default class FileWriter {
   }
 
   async stop() {
-    if (this.fd != null) {
-      await fs.close(this.fd);
-      this.fd = null;
-      await this.releaseLock!();
+    this.stopping = true;
+    this.stopPromise ||= this.stopInternal();
+    return this.stopPromise;
+  }
+
+  private async stopInternal() {
+    await Promise.allSettled(this.pendingWrites);
+
+    let cleanupError: unknown;
+    const fd = this.fd;
+    this.fd = null;
+    if (fd != null) {
+      try {
+        await fs.close(fd);
+      } catch (error) {
+        cleanupError ||= error;
+      }
+    }
+
+    const releaseLock = this.releaseLock;
+    this.releaseLock = undefined;
+    if (releaseLock) {
+      try {
+        await releaseLock();
+      } catch (error) {
+        cleanupError ||= error;
+      }
+    }
+
+    if (this.ownsFile) {
+      try {
+        await fs.remove(this.path);
+      } catch (error) {
+        cleanupError ||= error;
+      }
     }
     if (this.id != null) {
       uploadManager.delete(this.id);
     }
-    await fs.remove(this.path);
+
     logger.info("Browser Upload Task Stopped:", this.path);
+    if (cleanupError) throw cleanupError;
   }
 
   private addWrittenRange(start: number, end: number): void {

--- a/daemon/src/entity/file_writer.ts
+++ b/daemon/src/entity/file_writer.ts
@@ -15,6 +15,7 @@ export default class FileWriter {
   cwd?: string;
   private releaseLock?: () => Promise<void>;
   private fd: number | null = null;
+  private completion?: Promise<void>;
   readonly received: ChunkRange[] = [];
   lastUpdate: number = Date.now();
 
@@ -104,10 +105,16 @@ export default class FileWriter {
 
     this.addWrittenRange(offset, offset + chunk.length);
     if (this.isFullyCovered()) {
-      this.done().catch((e) => {
-        logger.error("Error completing file upload:", e);
-      }); // async
+      await this.complete();
     }
+  }
+
+  private complete(): Promise<void> {
+    this.completion ||= this.done().catch((error) => {
+      logger.error("Error completing file upload:", error);
+      throw error;
+    });
+    return this.completion;
   }
 
   async done() {
@@ -127,11 +134,15 @@ export default class FileWriter {
     logger.info("Browser Uploaded File:", this.path);
 
     if (this.unzip) {
-      // Statistics of the number of tasks in a single instance file and the number of tasks in the entire daemon process
+      this.startExtraction();
+    }
+  }
 
-      globalEnv.fileTaskCount++;
-      if (this.instance) this.instance.info.fileLock++;
+  private startExtraction(): void {
+    globalEnv.fileTaskCount++;
+    if (this.instance) this.instance.info.fileLock++;
 
+    void (async () => {
       try {
         const instanceFiles = new FileManager(this.cwd);
         await instanceFiles.unzip(this.path, path.dirname(this.path), this.zipCode);
@@ -141,11 +152,13 @@ export default class FileWriter {
           await fs.remove(this.path);
           logger.info("Temporary zip deleted:", this.path);
         }
+      } catch (error) {
+        logger.error("Error extracting uploaded archive:", this.path, error);
       } finally {
         globalEnv.fileTaskCount--;
         if (this.instance) this.instance.info.fileLock--;
       }
-    }
+    })();
   }
 
   async stop() {
@@ -194,7 +207,7 @@ export default class FileWriter {
   /** Complete the upload when no further pieces are expected (e.g. empty files). */
   async completeIfCovered() {
     if (this.fd != null && this.isFullyCovered()) {
-      await this.done();
+      await this.complete();
     }
   }
 

--- a/daemon/src/routers/file_router.ts
+++ b/daemon/src/routers/file_router.ts
@@ -276,13 +276,11 @@ routerApp.on("file/delete", async (ctx, data) => {
       const uploadTask = uploadManager.getByPath(path);
       const downloadTask = downloadManager.tasks.find((t) => t.path === path);
       if (uploadTask != undefined) {
-        uploadManager.delete(uploadTask.id);
-        uploadTask.writer.stop();
+        await uploadTask.writer.stop();
       } else if (downloadTask != undefined) {
         downloadManager.stop(path);
       } else {
-        // async delete
-        fileManager.delete(target);
+        await fileManager.delete(target, { ignoreMissing: true });
       }
     }
     protocol.response(ctx, true);

--- a/daemon/src/routers/http_router.ts
+++ b/daemon/src/routers/http_router.ts
@@ -224,13 +224,13 @@ router.post("/upload-piece/:id", async (ctx) => {
     const chunk = await fs.readFile(uploadedFile.filepath);
     await writer.write(offset, chunk);
 
-    if (tmpFiles) clearUploadFiles(tmpFiles);
-
     ctx.body = "OK";
     return;
   } catch (error: any) {
     ctx.body = error.message;
     ctx.status = 500;
+  } finally {
+    if (tmpFiles) clearUploadFiles(tmpFiles);
   }
 });
 

--- a/daemon/src/service/system_file.ts
+++ b/daemon/src/service/system_file.ts
@@ -241,12 +241,14 @@ export default class FileManager {
     return fs.mkdirSync(targetPath, { recursive: true });
   }
 
-  async delete(target: string): Promise<boolean> {
-    if (!this.check(target)) throw new Error(ERROR_MSG_01);
+  async delete(target: string, options: { ignoreMissing?: boolean } = {}): Promise<boolean> {
+    if (!this.checkPath(target)) throw new Error(ERROR_MSG_01);
     const targetPath = this.toAbsolutePath(target);
+    if (!options.ignoreMissing && !fs.existsSync(targetPath)) throw new Error(ERROR_MSG_01);
     return new Promise((r, j) => {
       fs.remove(targetPath, (err) => {
-        if (!err) r(true);
+        if (!err || (options.ignoreMissing && (err as NodeJS.ErrnoException).code === "ENOENT"))
+          r(true);
         else j(err);
       });
     });

--- a/frontend/src/assets/xterm.scss
+++ b/frontend/src/assets/xterm.scss
@@ -153,6 +153,117 @@
   color: transparent;
 }
 
+.xterm-touch-host {
+  position: relative;
+  overscroll-behavior: contain;
+  -webkit-touch-callout: none;
+}
+
+.xterm-touch-host .xterm-viewport {
+  overscroll-behavior: contain;
+}
+
+.xterm-touch-host.touch-scrolling {
+  touch-action: none;
+}
+
+.xterm-touch-selection-ui {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  pointer-events: none;
+}
+
+.xterm-touch-selection-handle {
+  position: absolute;
+  width: 32px;
+  height: 38px;
+  pointer-events: auto;
+  touch-action: none;
+
+  &::before {
+    position: absolute;
+    top: -1px;
+    width: 2px;
+    height: 17px;
+    background: #d9d9d9;
+    content: "";
+  }
+
+  &::after {
+    position: absolute;
+    top: 13px;
+    width: 18px;
+    height: 18px;
+    border: 2px solid #595959;
+    border-radius: 50%;
+    background: #f5f5f5;
+    box-shadow: 0 1px 3px rgb(0 0 0 / 45%);
+    content: "";
+  }
+
+  &.is-start {
+    transform: translateX(-32px);
+
+    &::before {
+      right: 0;
+    }
+
+    &::after {
+      right: -8px;
+    }
+  }
+
+  &.is-end {
+    &::before {
+      left: 0;
+    }
+
+    &::after {
+      left: -8px;
+    }
+  }
+
+  &.is-dragging::after {
+    background: #ffffff;
+    transform: scale(1.12);
+  }
+}
+
+.xterm-touch-selection-toolbar {
+  position: absolute;
+  display: flex;
+  min-height: 36px;
+  overflow: hidden;
+  border: 1px solid #595959;
+  border-radius: 6px;
+  background: #262626;
+  box-shadow: 0 3px 10px rgb(0 0 0 / 45%);
+  pointer-events: auto;
+  touch-action: none;
+
+  button {
+    min-width: 52px;
+    min-height: 36px;
+    padding: 7px 12px;
+    border: 0;
+    border-right: 1px solid #434343;
+    background: transparent;
+    color: #f5f5f5;
+    font: inherit;
+    font-size: 13px;
+    cursor: pointer;
+
+    &:last-child {
+      border-right: 0;
+    }
+
+    &:active {
+      background: #434343;
+    }
+  }
+}
+
 .xterm .live-region {
   position: absolute;
   left: -9999px;

--- a/frontend/src/hooks/terminalTouchSelection.ts
+++ b/frontend/src/hooks/terminalTouchSelection.ts
@@ -1,0 +1,27 @@
+import type { IBuffer } from "@xterm/xterm";
+
+export function snapSelectionStart(buffer: IBuffer, columns: number, index: number): number {
+  const row = Math.floor(index / columns);
+  let column = index % columns;
+  const line = buffer.getLine(row);
+
+  while (column > 0 && line?.getCell(column)?.getWidth() === 0) {
+    column--;
+  }
+
+  return row * columns + column;
+}
+
+export function snapSelectionEnd(buffer: IBuffer, columns: number, index: number): number {
+  if (index % columns === 0) return index;
+
+  const row = Math.floor(index / columns);
+  let column = index % columns;
+  const line = buffer.getLine(row);
+
+  while (column < columns && line?.getCell(column)?.getWidth() === 0) {
+    column++;
+  }
+
+  return row * columns + column;
+}

--- a/frontend/src/hooks/useFileManager.ts
+++ b/frontend/src/hooks/useFileManager.ts
@@ -295,7 +295,7 @@ export const useFileManager = (instanceId: string = "", daemonId: string = "") =
     });
   };
 
-  const getFileList = async (throwErr = false, initPath?: string) => {
+  const getFileList = async (throwErr = false, initPath?: string, forceRequest = false) => {
     const { execute } = getFileListApi();
     const thisTab = currentTabs.value.find((e) => e.key === activeTab.value);
 
@@ -309,6 +309,7 @@ export const useFileManager = (instanceId: string = "", daemonId: string = "") =
         path = currentPath.value;
       }
       const res = await execute({
+        forceRequest,
         params: {
           daemonId: daemonId || "",
           uuid: instanceId || "",
@@ -560,27 +561,36 @@ export const useFileManager = (instanceId: string = "", daemonId: string = "") =
 
   const refreshUploadTarget = async (path: string) => {
     if (!isViewingTargetPath(path)) return;
-    await getFileList();
+    await getFileList(false, undefined, true);
   };
 
   const waitForInstanceFileTasks = async (baselineTaskCount: number, timeout = 15000) => {
     const startTime = Date.now();
-    await sleep(500);
+    let taskStarted = false;
+    const taskStartGracePeriod = 2000;
 
     while (Date.now() - startTime < timeout) {
-      await getFileStatus();
+      await getFileStatus(true);
       const taskCount = fileStatus.value?.instanceFileTask ?? 0;
-      if (taskCount <= baselineTaskCount) return;
+      if (taskCount > baselineTaskCount) {
+        taskStarted = true;
+      } else if (taskStarted) {
+        return;
+      } else if (Date.now() - startTime >= taskStartGracePeriod) {
+        return;
+      }
       await sleep(500);
     }
   };
 
   const createUploadCompletionTracker = (handler: () => void | Promise<void>) => {
     let pendingCount = 0;
+    let boundCount = 0;
+    let closed = false;
     let finished = false;
 
     const handleCompletion = () => {
-      if (finished) return;
+      if (!closed || pendingCount > 0 || boundCount === 0 || finished) return;
       finished = true;
       void Promise.resolve(handler()).catch((error) => {
         console.error("Failed to handle upload completion:", error);
@@ -590,14 +600,19 @@ export const useFileManager = (instanceId: string = "", daemonId: string = "") =
     return {
       bind(task: ReturnType<typeof uploadService.append>) {
         pendingCount += 1;
+        boundCount += 1;
         task.instanceInfo = {
           instanceId: instanceId || "",
           daemonId: daemonId || ""
         };
         task.addCallback("end", () => {
           pendingCount -= 1;
-          if (pendingCount === 0) handleCompletion();
+          handleCompletion();
         });
+      },
+      close() {
+        closed = true;
+        handleCompletion();
       }
     };
   };
@@ -705,6 +720,7 @@ export const useFileManager = (instanceId: string = "", daemonId: string = "") =
     const targetPath = overridePath || currentPath.value;
     const uploadQueue: SelectedUploadFile[] = files.map((file) => ({ file, overwrite: false }));
     const completionTracker = createUploadCompletionTracker(async () => {
+      await sleep(300);
       await refreshUploadTarget(targetPath);
       if (onComplete) await onComplete();
     });
@@ -768,11 +784,14 @@ export const useFileManager = (instanceId: string = "", daemonId: string = "") =
           );
         } catch (err: any) {
           console.error(err);
+          completionTracker.close();
           return reportErrorMsg(err.response?.data || err.message);
         }
       }
+      completionTracker.close();
     } catch (err: any) {
       console.error(err);
+      completionTracker.close();
       return reportErrorMsg(err.response?.data || err.message);
     }
   };
@@ -794,7 +813,7 @@ export const useFileManager = (instanceId: string = "", daemonId: string = "") =
 
     const startUpload = async () => {
       const targetPath = currentPath.value;
-      await getFileStatus();
+      await getFileStatus(true);
       const baselineTaskCount = fileStatus.value?.instanceFileTask ?? 0;
       const zipKey = `zip_${folderName}`;
 
@@ -867,6 +886,7 @@ export const useFileManager = (instanceId: string = "", daemonId: string = "") =
             completionTracker.bind(task);
           }
         );
+        completionTracker.close();
 
         message.loading({ content: t("TXT_CODE_b82225c3"), key: zipKey });
       } catch (error: any) {
@@ -1078,10 +1098,11 @@ export const useFileManager = (instanceId: string = "", daemonId: string = "") =
     getFileList();
   };
 
-  const getFileStatus = async () => {
+  const getFileStatus = async (forceRequest = false) => {
     const { state, execute } = getFileStatusApi();
     try {
       await execute({
+        forceRequest,
         params: {
           daemonId: daemonId || "",
           uuid: instanceId || ""

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -18,6 +18,7 @@ import type { Socket } from "socket.io-client";
 import { computed, onMounted, onUnmounted, ref, unref } from "vue";
 import { makeSocketIo } from "./useSocketIo";
 import { createTerminalHistoryReplayGate } from "./terminalHistoryReplayGate";
+import { attachTerminalTouchControls } from "./useTerminalTouch";
 
 export const TERM_COLOR = {
   TERM_RESET: "\x1B[0m",
@@ -81,6 +82,7 @@ export function useTerminal() {
   });
 
   let fitAddonTask: NodeJS.Timer;
+  let removeTouchHandlers: (() => void) | undefined;
   let cachedSize = {
     w: 160,
     h: 40
@@ -187,60 +189,15 @@ export function useTerminal() {
     });
   };
 
-  const touchHandler = (event: TouchEvent) => {
-    const touches = event.changedTouches;
-    const first = touches[0];
-
-    let type = "";
-    switch (event.type) {
-      case "touchstart":
-        type = "mousedown";
-        break;
-      case "touchmove":
-        type = "mousemove";
-        break;
-      case "touchend":
-        type = "mouseup";
-        break;
-      default:
-        return;
-    }
-
-    const mouseEvent = new MouseEvent(type, {
-      bubbles: true,
-      cancelable: true,
-      view: window,
-      detail: 1,
-      screenX: first.screenX,
-      screenY: first.screenY,
-      clientX: first.clientX,
-      clientY: first.clientY,
-      ctrlKey: false,
-      altKey: false,
-      shiftKey: false,
-      metaKey: false,
-      button: 0,
-      relatedTarget: null
-    });
-
-    first.target.dispatchEvent(mouseEvent);
-    if (type === "mousedown") {
-      event.preventDefault();
-    }
-  };
-
   const initTerminalWindow = (element: HTMLElement) => {
     if (terminal.value) {
       throw new Error("Terminal already initialized, Please refresh the page!");
     }
 
-    // init touch handler
-    element.addEventListener("touchstart", touchHandler, true);
-    element.addEventListener("touchmove", touchHandler, true);
-    element.addEventListener("touchend", touchHandler, true);
-    element.addEventListener("touchcancel", touchHandler, true);
-
+    const isTouchCapable =
+      window.matchMedia("(pointer: coarse)").matches || navigator.maxTouchPoints > 0;
     const background = hasBgImage.value ? "#00000000" : "#1e1e1e";
+    const selectionBackground = "rgba(255, 255, 255, 0.3)";
     const term = new Terminal({
       convertEol: true,
       disableStdin: false,
@@ -248,7 +205,8 @@ export function useTerminal() {
       cursorBlink: true,
       fontSize: 14,
       theme: {
-        background
+        background,
+        selectionBackground
       },
       allowProposedApi: true,
       allowTransparency: true
@@ -277,6 +235,15 @@ export function useTerminal() {
     }
 
     term.open(element);
+    if (isTouchCapable) {
+      removeTouchHandlers = attachTerminalTouchControls({
+        element,
+        terminal: term,
+        canPaste: () =>
+          state.value?.config.terminalOption?.pty === true &&
+          state.value?.status !== INSTANCE_STATUS_CODE.STOPPED
+      });
+    }
 
     // If text is selected, copy it. Otherwise, fallback to default behavior.
     term.attachCustomKeyEventHandler((arg) => {
@@ -369,11 +336,10 @@ export function useTerminal() {
   };
 
   events.on("stdout", (v: StdoutData) => {
-    if (state.value?.config?.terminalOption?.haveColor) {
-      terminal.value?.write(encodeConsoleColor(v.text));
-    } else {
-      terminal.value?.write(v.text);
-    }
+    const output = state.value?.config?.terminalOption?.haveColor
+      ? encodeConsoleColor(v.text)
+      : v.text;
+    terminal.value?.write(output);
   });
 
   const sendCommand = (command: string) => {
@@ -396,6 +362,10 @@ export function useTerminal() {
   onUnmounted(() => {
     clearInterval(fitAddonTask);
     clearInterval(statusQueryTask);
+    removeTouchHandlers?.();
+    removeTouchHandlers = undefined;
+    terminal.value?.dispose();
+    terminal.value = undefined;
     events.removeAllListeners();
     isManualDisconnect = true;
     socket?.disconnect();

--- a/frontend/src/hooks/useTerminalTouch.dom.test.ts
+++ b/frontend/src/hooks/useTerminalTouch.dom.test.ts
@@ -1,0 +1,251 @@
+// @vitest-environment jsdom
+
+import type { IBuffer, IMarker, Terminal } from "@xterm/xterm";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { attachTerminalTouchControls } from "./useTerminalTouch";
+
+vi.mock("@/lang/i18n", () => ({
+  t: (key: string) => key
+}));
+
+vi.mock("@/tools/copy", () => ({
+  toCopy: vi.fn()
+}));
+
+vi.mock("ant-design-vue", () => ({
+  message: { error: vi.fn() }
+}));
+
+function createTouchEvent(type: string, clientX: number, clientY: number): TouchEvent {
+  const event = new Event(type, { bubbles: true, cancelable: true }) as TouchEvent;
+  const touch = { clientX, clientY, pageY: clientY };
+  Object.defineProperty(event, "touches", {
+    value: type === "touchend" ? [] : [touch]
+  });
+  return event;
+}
+
+type MutableMarker = IMarker & { line: number };
+type TerminalMock = Terminal & {
+  emitWriteParsed: () => void;
+  trackedMarkers: MutableMarker[];
+};
+
+function createTerminalMock(viewportY = 0, length = 4): TerminalMock {
+  let hasSelection = false;
+  let writeParsedListener: (() => void) | undefined;
+  const trackedMarkers: MutableMarker[] = [];
+  const cells = Array.from({ length: 40 }, (_, column) => ({
+    getChars: () => (column < 5 ? "hello"[column] : " "),
+    getWidth: () => 1
+  }));
+  const buffer = {
+    type: "normal",
+    length,
+    viewportY,
+    baseY: viewportY,
+    cursorY: 3,
+    getLine: () => ({
+      getCell: (column: number) => cells[column]
+    })
+  } as unknown as IBuffer;
+  const disposable = () => ({ dispose: vi.fn() });
+  const terminal = {
+    buffer: { active: buffer },
+    cols: 10,
+    rows: 4,
+    blur: vi.fn(),
+    clearSelection: vi.fn(() => {
+      hasSelection = false;
+    }),
+    focus: vi.fn(),
+    getSelection: vi.fn(() => "hello"),
+    hasSelection: vi.fn(() => hasSelection),
+    onResize: vi.fn(disposable),
+    onScroll: vi.fn(disposable),
+    onSelectionChange: vi.fn(disposable),
+    onWriteParsed: vi.fn((listener: () => void) => {
+      writeParsedListener = listener;
+      return disposable();
+    }),
+    paste: vi.fn(),
+    registerMarker: vi.fn((cursorYOffset = 0) => {
+      const marker = {
+        id: trackedMarkers.length + 1,
+        line: buffer.baseY + buffer.cursorY + cursorYOffset,
+        onDispose: vi.fn(),
+        dispose: vi.fn()
+      } as unknown as MutableMarker;
+      marker.dispose = vi.fn(() => {
+        marker.line = -1;
+      });
+      trackedMarkers.push(marker);
+      return marker;
+    }),
+    scrollToLine: vi.fn(),
+    select: vi.fn(() => {
+      hasSelection = true;
+    })
+  } as unknown as TerminalMock;
+  terminal.trackedMarkers = trackedMarkers;
+  terminal.emitWriteParsed = () => writeParsedListener?.();
+  return terminal;
+}
+
+function createHost() {
+  const host = document.createElement("div");
+  const viewport = document.createElement("div");
+  viewport.className = "xterm-viewport";
+  const screen = document.createElement("div");
+  screen.className = "xterm-screen";
+  host.append(viewport, screen);
+  document.body.appendChild(host);
+
+  Object.defineProperty(host, "clientWidth", { value: 100 });
+  Object.defineProperty(host, "clientHeight", { value: 80 });
+  host.getBoundingClientRect = () => ({ left: 0, top: 0, width: 100, height: 80 }) as DOMRect;
+  screen.getBoundingClientRect = () => ({ left: 0, top: 0, width: 100, height: 80 }) as DOMRect;
+  return host;
+}
+
+describe("terminal touch controls", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("creates a cell-based word selection and shows both handles after a long press", () => {
+    const terminal = createTerminalMock();
+    const host = createHost();
+    const dispose = attachTerminalTouchControls({
+      element: host,
+      terminal,
+      canPaste: () => false
+    });
+
+    host.dispatchEvent(createTouchEvent("touchstart", 25, 10));
+    vi.advanceTimersByTime(500);
+
+    expect(terminal.select).toHaveBeenCalledWith(0, 0, 5);
+    expect(host.querySelector<HTMLElement>(".xterm-touch-selection-ui")?.hidden).toBe(false);
+    expect(host.querySelectorAll(".xterm-touch-selection-handle")).toHaveLength(2);
+    expect(
+      host.querySelectorAll<HTMLButtonElement>(".xterm-touch-selection-toolbar button")[1].hidden
+    ).toBe(true);
+
+    dispose();
+  });
+
+  it("clears an active selection when the terminal is touched again", () => {
+    const terminal = createTerminalMock();
+    const host = createHost();
+    const dispose = attachTerminalTouchControls({
+      element: host,
+      terminal,
+      canPaste: () => true
+    });
+
+    host.dispatchEvent(createTouchEvent("touchstart", 25, 10));
+    vi.advanceTimersByTime(500);
+    host.dispatchEvent(createTouchEvent("touchstart", 80, 60));
+
+    expect(terminal.clearSelection).toHaveBeenCalled();
+    expect(host.querySelector<HTMLElement>(".xterm-touch-selection-ui")?.hidden).toBe(true);
+
+    dispose();
+  });
+
+  it("does not focus the terminal for input when PTY input is unavailable", () => {
+    const terminal = createTerminalMock();
+    const host = createHost();
+    const dispose = attachTerminalTouchControls({
+      element: host,
+      terminal,
+      canPaste: () => false
+    });
+
+    host.dispatchEvent(createTouchEvent("touchstart", 25, 10));
+    host.dispatchEvent(createTouchEvent("touchend", 25, 10));
+
+    expect(terminal.focus).not.toHaveBeenCalled();
+
+    dispose();
+  });
+
+  it("keeps mouse context menus while suppressing touch-generated context menus", () => {
+    const terminal = createTerminalMock();
+    const host = createHost();
+    const dispose = attachTerminalTouchControls({
+      element: host,
+      terminal,
+      canPaste: () => true
+    });
+
+    const mouseContextMenu = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    host.dispatchEvent(mouseContextMenu);
+    expect(mouseContextMenu.defaultPrevented).toBe(false);
+
+    host.dispatchEvent(createTouchEvent("touchstart", 25, 10));
+    const touchContextMenu = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    host.dispatchEvent(touchContextMenu);
+    expect(touchContextMenu.defaultPrevented).toBe(true);
+
+    dispose();
+  });
+
+  it("swaps handle roles when the start handle is dragged past the end handle", () => {
+    const terminal = createTerminalMock();
+    const host = createHost();
+    const dispose = attachTerminalTouchControls({
+      element: host,
+      terminal,
+      canPaste: () => true
+    });
+
+    host.dispatchEvent(createTouchEvent("touchstart", 25, 10));
+    vi.advanceTimersByTime(500);
+
+    const startHandle = host.querySelector<HTMLElement>(".xterm-touch-selection-handle.is-start");
+    startHandle?.dispatchEvent(createTouchEvent("touchstart", 0, 20));
+    startHandle?.dispatchEvent(createTouchEvent("touchmove", 80, 20));
+
+    expect(terminal.select).toHaveBeenLastCalledWith(5, 0, 3);
+    expect(startHandle?.classList.contains("is-end")).toBe(true);
+
+    dispose();
+  });
+
+  it("keeps the selection anchored when scrollback trimming shifts buffer lines", () => {
+    const terminal = createTerminalMock(1, 6);
+    const host = createHost();
+    const dispose = attachTerminalTouchControls({
+      element: host,
+      terminal,
+      canPaste: () => true
+    });
+
+    host.dispatchEvent(createTouchEvent("touchstart", 25, 30));
+    vi.advanceTimersByTime(500);
+    expect(terminal.select).toHaveBeenLastCalledWith(0, 2, 5);
+
+    terminal.trackedMarkers.forEach((marker) => {
+      marker.line -= 1;
+    });
+    terminal.emitWriteParsed();
+
+    expect(terminal.scrollToLine).toHaveBeenLastCalledWith(0);
+    expect(terminal.select).toHaveBeenLastCalledWith(0, 1, 5);
+
+    dispose();
+  });
+});

--- a/frontend/src/hooks/useTerminalTouch.test.ts
+++ b/frontend/src/hooks/useTerminalTouch.test.ts
@@ -1,0 +1,31 @@
+import type { IBuffer } from "@xterm/xterm";
+import { describe, expect, it } from "vitest";
+import { snapSelectionEnd, snapSelectionStart } from "./terminalTouchSelection";
+
+function createBuffer(widths: number[]): IBuffer {
+  return {
+    getLine: () => ({
+      getCell: (column: number) => ({
+        getWidth: () => widths[column] ?? 1
+      })
+    })
+  } as unknown as IBuffer;
+}
+
+describe("terminal touch selection boundaries", () => {
+  it("moves a start boundary to the leading cell of a wide character", () => {
+    const buffer = createBuffer([1, 2, 0, 1]);
+    expect(snapSelectionStart(buffer, 4, 2)).toBe(1);
+  });
+
+  it("moves an end boundary past the continuation cell of a wide character", () => {
+    const buffer = createBuffer([1, 2, 0, 1]);
+    expect(snapSelectionEnd(buffer, 4, 2)).toBe(3);
+  });
+
+  it("keeps ordinary and wrapped-line boundaries unchanged", () => {
+    const buffer = createBuffer([1, 1, 1, 1]);
+    expect(snapSelectionStart(buffer, 4, 1)).toBe(1);
+    expect(snapSelectionEnd(buffer, 4, 4)).toBe(4);
+  });
+});

--- a/frontend/src/hooks/useTerminalTouch.ts
+++ b/frontend/src/hooks/useTerminalTouch.ts
@@ -1,0 +1,731 @@
+import { t } from "@/lang/i18n";
+import { toCopy } from "@/tools/copy";
+import type { IBuffer, IMarker, Terminal } from "@xterm/xterm";
+import { message } from "ant-design-vue";
+import { snapSelectionEnd, snapSelectionStart } from "./terminalTouchSelection";
+
+type SelectionEndpoint = "start" | "end";
+
+interface TerminalTouchOptions {
+  element: HTMLElement;
+  terminal: Terminal;
+  canPaste: () => boolean;
+}
+
+interface GridMetrics {
+  cellHeight: number;
+  cellWidth: number;
+  hostRect: DOMRect;
+  screenRect: DOMRect;
+}
+
+interface BoundaryPosition {
+  column: number;
+  row: number;
+}
+
+interface TrackedSelection {
+  endColumn: number;
+  endMarker: IMarker;
+  startColumn: number;
+  startMarker: IMarker;
+  viewportMarker: IMarker;
+}
+
+const MOVE_THRESHOLD = 8;
+const LONG_PRESS_DELAY = 500;
+const INERTIA_FRICTION = 0.94;
+const MAX_INERTIA_VELOCITY = 160;
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(Math.max(value, minimum), maximum);
+}
+
+function getCellClass(chars: string): "space" | "word" | "symbol" {
+  if (!chars || /^\s+$/u.test(chars)) return "space";
+  if (/^[\p{L}\p{N}_]+$/u.test(chars)) return "word";
+  return "symbol";
+}
+
+function getCellWidth(buffer: IBuffer, columns: number, index: number): number {
+  const row = Math.floor(index / columns);
+  const column = index % columns;
+  return buffer.getLine(row)?.getCell(column)?.getWidth() ?? 1;
+}
+
+function getWordRange(buffer: IBuffer, columns: number, row: number, column: number) {
+  const line = buffer.getLine(row);
+  if (!line) return { start: row * columns + column, end: row * columns + column + 1 };
+
+  while (column > 0 && line.getCell(column)?.getWidth() === 0) {
+    column--;
+  }
+
+  const initialCell = line.getCell(column);
+  const initialWidth = Math.max(initialCell?.getWidth() ?? 1, 1);
+  const cellClass = getCellClass(initialCell?.getChars() ?? "");
+  let startColumn = column;
+  let endColumn = Math.min(column + initialWidth, columns);
+
+  if (cellClass !== "space") {
+    while (startColumn > 0) {
+      let previousColumn = startColumn - 1;
+      while (previousColumn > 0 && line.getCell(previousColumn)?.getWidth() === 0) {
+        previousColumn--;
+      }
+      const previousCell = line.getCell(previousColumn);
+      if (!previousCell || getCellClass(previousCell.getChars()) !== cellClass) break;
+      startColumn = previousColumn;
+    }
+
+    while (endColumn < columns) {
+      const nextCell = line.getCell(endColumn);
+      if (!nextCell) break;
+      if (nextCell.getWidth() === 0) {
+        endColumn++;
+        continue;
+      }
+      if (getCellClass(nextCell.getChars()) !== cellClass) break;
+      endColumn = Math.min(endColumn + Math.max(nextCell.getWidth(), 1), columns);
+    }
+  }
+
+  return {
+    start: row * columns + startColumn,
+    end: row * columns + endColumn
+  };
+}
+
+export function attachTerminalTouchControls({
+  element,
+  terminal,
+  canPaste
+}: TerminalTouchOptions): () => void {
+  const viewport = element.querySelector<HTMLElement>(".xterm-viewport");
+  const screen = element.querySelector<HTMLElement>(".xterm-screen");
+  if (!viewport || !screen) return () => undefined;
+
+  element.classList.add("xterm-touch-host");
+
+  const selectionUi = document.createElement("div");
+  selectionUi.className = "xterm-touch-selection-ui";
+  selectionUi.hidden = true;
+
+  const startHandle = document.createElement("div");
+  startHandle.className = "xterm-touch-selection-handle is-start";
+  const endHandle = document.createElement("div");
+  endHandle.className = "xterm-touch-selection-handle is-end";
+  const handleEndpoints = new Map<HTMLElement, SelectionEndpoint>([
+    [startHandle, "start"],
+    [endHandle, "end"]
+  ]);
+
+  const toolbar = document.createElement("div");
+  toolbar.className = "xterm-touch-selection-toolbar";
+
+  const copyButton = document.createElement("button");
+  copyButton.type = "button";
+  copyButton.textContent = t("TXT_CODE_13ae6a93");
+
+  const pasteButton = document.createElement("button");
+  pasteButton.type = "button";
+  pasteButton.textContent = t("TXT_CODE_43248597");
+
+  const cancelButton = document.createElement("button");
+  cancelButton.type = "button";
+  cancelButton.textContent = t("TXT_CODE_abedfd03");
+
+  toolbar.append(copyButton, pasteButton, cancelButton);
+  selectionUi.append(startHandle, endHandle, toolbar);
+  element.appendChild(selectionUi);
+
+  let selectionStart = 0;
+  let selectionEnd = 0;
+  let selectionViewportY: number | undefined;
+  let selectionActive = false;
+  let touchStartX = 0;
+  let touchStartY = 0;
+  let touchMoved = false;
+  let longPressActive = false;
+  let longPressTimer: ReturnType<typeof setTimeout> | undefined;
+  let longPressAnchorStart = 0;
+  let longPressAnchorEnd = 0;
+  let lastTouchY = 0;
+  let lastMoveTime = 0;
+  let velocityY = 0;
+  let inertiaFrame: number | undefined;
+  let suppressMouseUntil = 0;
+  let suppressTouchContextMenuUntil = 0;
+  let selectionDismissedByTouch = false;
+  let uiUpdateFrame: number | undefined;
+  let trackedSelection: TrackedSelection | undefined;
+
+  const getMetrics = (): GridMetrics | undefined => {
+    const screenRect = screen.getBoundingClientRect();
+    if (!terminal.cols || !terminal.rows || !screenRect.width || !screenRect.height) return;
+    return {
+      cellWidth: screenRect.width / terminal.cols,
+      cellHeight: screenRect.height / terminal.rows,
+      hostRect: element.getBoundingClientRect(),
+      screenRect
+    };
+  };
+
+  const getVisualBoundary = (index: number, endpoint: SelectionEndpoint): BoundaryPosition => {
+    let row = Math.floor(index / terminal.cols);
+    let column = index % terminal.cols;
+    if (endpoint === "end" && column === 0 && index > selectionStart) {
+      row--;
+      column = terminal.cols;
+    }
+    return { column, row };
+  };
+
+  const setHandleEndpoint = (handle: HTMLElement, endpoint: SelectionEndpoint) => {
+    handleEndpoints.set(handle, endpoint);
+    handle.classList.toggle("is-start", endpoint === "start");
+    handle.classList.toggle("is-end", endpoint === "end");
+  };
+
+  const resetHandleEndpoints = () => {
+    setHandleEndpoint(startHandle, "start");
+    setHandleEndpoint(endHandle, "end");
+  };
+
+  const swapHandleEndpoints = (draggedHandle: HTMLElement) => {
+    const otherHandle = draggedHandle === startHandle ? endHandle : startHandle;
+    const nextEndpoint = handleEndpoints.get(draggedHandle) === "start" ? "end" : "start";
+    setHandleEndpoint(draggedHandle, nextEndpoint);
+    setHandleEndpoint(otherHandle, nextEndpoint === "start" ? "end" : "start");
+    return nextEndpoint;
+  };
+
+  const getBoundaryClientPosition = (endpoint: SelectionEndpoint) => {
+    const metrics = getMetrics();
+    if (!metrics) return;
+    const index = endpoint === "start" ? selectionStart : selectionEnd;
+    const boundary = getVisualBoundary(index, endpoint);
+    return {
+      x: metrics.screenRect.left + boundary.column * metrics.cellWidth,
+      y:
+        metrics.screenRect.top +
+        (boundary.row - terminal.buffer.active.viewportY + 1) * metrics.cellHeight
+    };
+  };
+
+  const updateSelectionUi = () => {
+    uiUpdateFrame = undefined;
+    if (!selectionActive) return;
+    const metrics = getMetrics();
+    if (!metrics) return;
+
+    const viewportY = terminal.buffer.active.viewportY;
+    const positions = [startHandle, endHandle].map((handle) => {
+      const endpoint = handleEndpoints.get(handle) ?? "start";
+      const index = endpoint === "start" ? selectionStart : selectionEnd;
+      const boundary = getVisualBoundary(index, endpoint);
+      const visible = boundary.row >= viewportY && boundary.row < viewportY + terminal.rows;
+      handle.hidden = !visible;
+      const x =
+        metrics.screenRect.left - metrics.hostRect.left + boundary.column * metrics.cellWidth;
+      const y =
+        metrics.screenRect.top -
+        metrics.hostRect.top +
+        (boundary.row - viewportY + 1) * metrics.cellHeight;
+      handle.style.left = `${x}px`;
+      handle.style.top = `${y}px`;
+      return { visible, x, y };
+    });
+
+    pasteButton.hidden = !canPaste();
+
+    const visiblePositions = positions.filter((position) => position.visible);
+    const toolbarWidth = toolbar.offsetWidth;
+    const toolbarHeight = toolbar.offsetHeight;
+    const centerX = visiblePositions.length
+      ? visiblePositions.reduce((total, position) => total + position.x, 0) /
+        visiblePositions.length
+      : metrics.screenRect.left - metrics.hostRect.left + metrics.screenRect.width / 2;
+    const topY = visiblePositions.length
+      ? Math.min(...visiblePositions.map((position) => position.y))
+      : metrics.screenRect.top - metrics.hostRect.top;
+    const bottomY = visiblePositions.length
+      ? Math.max(...visiblePositions.map((position) => position.y))
+      : topY;
+    const maximumLeft = Math.max(element.clientWidth - toolbarWidth - 4, 4);
+    toolbar.style.left = `${clamp(centerX - toolbarWidth / 2, 4, maximumLeft)}px`;
+    toolbar.style.top = `${
+      topY - toolbarHeight - 10 >= 4
+        ? topY - toolbarHeight - 10
+        : Math.min(bottomY + 22, element.clientHeight - toolbarHeight - 4)
+    }px`;
+  };
+
+  const scheduleSelectionUiUpdate = () => {
+    if (uiUpdateFrame !== undefined) return;
+    uiUpdateFrame = requestAnimationFrame(updateSelectionUi);
+  };
+
+  const disposeTrackedSelection = () => {
+    if (!trackedSelection) return;
+    trackedSelection.viewportMarker.dispose();
+    trackedSelection.startMarker.dispose();
+    trackedSelection.endMarker.dispose();
+    trackedSelection = undefined;
+  };
+
+  const trackSelection = () => {
+    disposeTrackedSelection();
+    const buffer = terminal.buffer.active;
+    if (buffer.type !== "normal") return;
+
+    const cursorRow = buffer.baseY + buffer.cursorY;
+    const endBoundary = getVisualBoundary(selectionEnd, "end");
+    trackedSelection = {
+      viewportMarker: terminal.registerMarker(buffer.viewportY - cursorRow),
+      startMarker: terminal.registerMarker(Math.floor(selectionStart / terminal.cols) - cursorRow),
+      startColumn: selectionStart % terminal.cols,
+      endMarker: terminal.registerMarker(endBoundary.row - cursorRow),
+      endColumn: endBoundary.column
+    };
+  };
+
+  const applySelection = () => {
+    const maximumIndex = terminal.buffer.active.length * terminal.cols;
+    selectionStart = clamp(selectionStart, 0, Math.max(maximumIndex - 1, 0));
+    selectionEnd = clamp(selectionEnd, selectionStart + 1, maximumIndex);
+    terminal.select(
+      selectionStart % terminal.cols,
+      Math.floor(selectionStart / terminal.cols),
+      selectionEnd - selectionStart
+    );
+    trackSelection();
+    scheduleSelectionUiUpdate();
+  };
+
+  const clearSelection = () => {
+    selectionActive = false;
+    selectionViewportY = undefined;
+    disposeTrackedSelection();
+    selectionUi.hidden = true;
+    terminal.clearSelection();
+    element.classList.remove("touch-selection-active");
+  };
+
+  const beginSelection = (clientX: number, clientY: number) => {
+    const metrics = getMetrics();
+    if (!metrics) return false;
+    const viewportRow = clamp(
+      Math.floor((clientY - metrics.screenRect.top) / metrics.cellHeight),
+      0,
+      terminal.rows - 1
+    );
+    const row = terminal.buffer.active.viewportY + viewportRow;
+    const column = clamp(
+      Math.floor((clientX - metrics.screenRect.left) / metrics.cellWidth),
+      0,
+      terminal.cols - 1
+    );
+    const range = getWordRange(terminal.buffer.active, terminal.cols, row, column);
+    resetHandleEndpoints();
+    selectionStart = range.start;
+    selectionEnd = range.end;
+    longPressAnchorStart = range.start;
+    longPressAnchorEnd = range.end;
+    selectionViewportY = terminal.buffer.active.viewportY;
+    selectionActive = true;
+    selectionUi.hidden = false;
+    element.classList.add("touch-selection-active");
+    applySelection();
+    return true;
+  };
+
+  const pointToCellRange = (clientX: number, clientY: number) => {
+    const metrics = getMetrics();
+    if (!metrics) return;
+    const viewportRow = clamp(
+      Math.floor((clientY - metrics.screenRect.top) / metrics.cellHeight),
+      0,
+      terminal.rows - 1
+    );
+    const row = terminal.buffer.active.viewportY + viewportRow;
+    const column = clamp(
+      Math.floor((clientX - metrics.screenRect.left) / metrics.cellWidth),
+      0,
+      terminal.cols - 1
+    );
+    const index = row * terminal.cols + column;
+    const start = snapSelectionStart(terminal.buffer.active, terminal.cols, index);
+    return {
+      start,
+      end: snapSelectionEnd(
+        terminal.buffer.active,
+        terminal.cols,
+        start + Math.max(getCellWidth(terminal.buffer.active, terminal.cols, start), 1)
+      )
+    };
+  };
+
+  const pointToBoundaryIndex = (clientX: number, clientY: number, endpoint: SelectionEndpoint) => {
+    const metrics = getMetrics();
+    if (!metrics) return endpoint === "start" ? selectionStart : selectionEnd;
+    const viewportRow = clamp(
+      Math.round((clientY - metrics.screenRect.top) / metrics.cellHeight) - 1,
+      0,
+      terminal.rows - 1
+    );
+    const row = terminal.buffer.active.viewportY + viewportRow;
+    const column = clamp(
+      Math.round((clientX - metrics.screenRect.left) / metrics.cellWidth),
+      0,
+      terminal.cols
+    );
+    const index = row * terminal.cols + column;
+    return endpoint === "start"
+      ? snapSelectionStart(terminal.buffer.active, terminal.cols, index)
+      : snapSelectionEnd(terminal.buffer.active, terminal.cols, index);
+  };
+
+  const stopInertia = () => {
+    if (inertiaFrame !== undefined) {
+      cancelAnimationFrame(inertiaFrame);
+      inertiaFrame = undefined;
+    }
+    velocityY = 0;
+  };
+
+  const clearLongPress = () => {
+    if (longPressTimer !== undefined) {
+      clearTimeout(longPressTimer);
+      longPressTimer = undefined;
+    }
+  };
+
+  const resetTouchState = () => {
+    clearLongPress();
+    touchMoved = false;
+    longPressActive = false;
+  };
+
+  const runInertia = () => {
+    if (Math.abs(velocityY) < 0.1) {
+      inertiaFrame = undefined;
+      velocityY = 0;
+      return;
+    }
+    viewport.scrollTop += velocityY;
+    velocityY *= INERTIA_FRICTION;
+    inertiaFrame = requestAnimationFrame(runInertia);
+  };
+
+  const isSelectionUiTarget = (target: EventTarget | null) =>
+    target instanceof Element && Boolean(target.closest(".xterm-touch-selection-ui"));
+
+  const handleTouchStart = (event: TouchEvent) => {
+    if (isSelectionUiTarget(event.target)) return;
+    if (event.touches.length !== 1) {
+      resetTouchState();
+      stopInertia();
+      return;
+    }
+
+    event.stopImmediatePropagation();
+    suppressTouchContextMenuUntil = Date.now() + LONG_PRESS_DELAY + 1000;
+    terminal.blur();
+    (document.activeElement as HTMLElement | null)?.blur();
+    stopInertia();
+
+    const touch = event.touches[0];
+    selectionDismissedByTouch = false;
+    if (selectionActive) {
+      clearSelection();
+      selectionDismissedByTouch = true;
+    }
+
+    touchStartX = touch.clientX;
+    touchStartY = touch.clientY;
+    lastTouchY = touch.pageY;
+    lastMoveTime = performance.now();
+    touchMoved = false;
+    longPressActive = false;
+    clearLongPress();
+    if (!selectionDismissedByTouch) {
+      longPressTimer = setTimeout(() => {
+        longPressTimer = undefined;
+        if (!touchMoved && beginSelection(touchStartX, touchStartY)) {
+          longPressActive = true;
+        }
+      }, LONG_PRESS_DELAY);
+    }
+  };
+
+  const handleTouchMove = (event: TouchEvent) => {
+    if (isSelectionUiTarget(event.target) || event.touches.length !== 1) return;
+    event.stopImmediatePropagation();
+    const touch = event.touches[0];
+
+    if (longPressActive && selectionActive) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      const range = pointToCellRange(touch.clientX, touch.clientY);
+      if (!range) return;
+      if (range.start < longPressAnchorStart) {
+        selectionStart = range.start;
+        selectionEnd = longPressAnchorEnd;
+      } else {
+        selectionStart = longPressAnchorStart;
+        selectionEnd = Math.max(range.end, longPressAnchorEnd);
+      }
+      applySelection();
+      return;
+    }
+
+    const distance = Math.hypot(touch.clientX - touchStartX, touch.clientY - touchStartY);
+    if (!touchMoved && distance > MOVE_THRESHOLD) {
+      touchMoved = true;
+      clearLongPress();
+      element.classList.add("touch-scrolling");
+      terminal.blur();
+    }
+
+    if (touchMoved) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }
+
+    const now = performance.now();
+    const deltaTime = now - lastMoveTime;
+    const deltaY = lastTouchY - touch.pageY;
+    if (touchMoved) viewport.scrollTop += deltaY;
+    if (touchMoved && deltaTime > 0) {
+      const nextVelocity = clamp(
+        (deltaY / deltaTime) * 16,
+        -MAX_INERTIA_VELOCITY,
+        MAX_INERTIA_VELOCITY
+      );
+      velocityY = velocityY * 0.35 + nextVelocity * 0.65;
+    }
+    lastTouchY = touch.pageY;
+    lastMoveTime = now;
+  };
+
+  const handleTouchEnd = (event: TouchEvent) => {
+    if (isSelectionUiTarget(event.target)) return;
+    event.stopImmediatePropagation();
+    suppressMouseUntil = Date.now() + 700;
+    if (selectionActive) {
+      stopInertia();
+    } else if (touchMoved && !longPressActive) {
+      inertiaFrame = requestAnimationFrame(runInertia);
+    } else if (!touchMoved && !longPressActive && !selectionDismissedByTouch && canPaste()) {
+      terminal.focus();
+    }
+    element.classList.remove("touch-scrolling");
+    resetTouchState();
+    selectionDismissedByTouch = false;
+  };
+
+  const handleTouchCancel = (event: TouchEvent) => {
+    if (isSelectionUiTarget(event.target)) return;
+    event.stopImmediatePropagation();
+    suppressMouseUntil = Date.now() + 700;
+    element.classList.remove("touch-scrolling");
+    resetTouchState();
+    stopInertia();
+  };
+
+  const handleCompatibilityMouseDown = (event: MouseEvent) => {
+    if (Date.now() >= suppressMouseUntil) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  };
+
+  const handleContextMenu = (event: MouseEvent) => {
+    if (Date.now() >= suppressTouchContextMenuUntil) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  };
+
+  const handleDocumentTouchStart = (event: TouchEvent) => {
+    if (selectionActive && event.target instanceof Node && !element.contains(event.target)) {
+      clearSelection();
+    }
+  };
+
+  const attachHandle = (handle: HTMLElement) => {
+    let dragOffsetX = 0;
+    let dragOffsetY = 0;
+    let draggedEndpoint: SelectionEndpoint = "start";
+
+    const handleDragStart = (event: TouchEvent) => {
+      if (event.touches.length !== 1) return;
+      event.preventDefault();
+      event.stopPropagation();
+      stopInertia();
+      draggedEndpoint = handleEndpoints.get(handle) ?? "start";
+      const position = getBoundaryClientPosition(draggedEndpoint);
+      if (!position) return;
+      dragOffsetX = event.touches[0].clientX - position.x;
+      dragOffsetY = event.touches[0].clientY - position.y;
+      handle.classList.add("is-dragging");
+    };
+
+    const handleDragMove = (event: TouchEvent) => {
+      if (event.touches.length !== 1 || !handle.classList.contains("is-dragging")) return;
+      event.preventDefault();
+      event.stopPropagation();
+      const touch = event.touches[0];
+      const clientX = touch.clientX - dragOffsetX;
+      const clientY = touch.clientY - dragOffsetY;
+      const startIndex = pointToBoundaryIndex(clientX, clientY, "start");
+      const endIndex = pointToBoundaryIndex(clientX, clientY, "end");
+      if (draggedEndpoint === "start" && startIndex > selectionEnd) {
+        selectionStart = selectionEnd;
+        selectionEnd = Math.max(endIndex, selectionStart + 1);
+        draggedEndpoint = swapHandleEndpoints(handle);
+      } else if (draggedEndpoint === "end" && endIndex < selectionStart) {
+        selectionEnd = selectionStart;
+        selectionStart = Math.min(startIndex, selectionEnd - 1);
+        draggedEndpoint = swapHandleEndpoints(handle);
+      } else if (draggedEndpoint === "start") {
+        selectionStart = Math.min(startIndex, selectionEnd - 1);
+      } else {
+        selectionEnd = Math.max(endIndex, selectionStart + 1);
+      }
+      applySelection();
+    };
+
+    const handleDragEnd = (event: TouchEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      handle.classList.remove("is-dragging");
+    };
+
+    handle.addEventListener("touchstart", handleDragStart, { passive: false });
+    handle.addEventListener("touchmove", handleDragMove, { passive: false });
+    handle.addEventListener("touchend", handleDragEnd, { passive: false });
+    handle.addEventListener("touchcancel", handleDragEnd, { passive: false });
+
+    return () => {
+      handle.removeEventListener("touchstart", handleDragStart);
+      handle.removeEventListener("touchmove", handleDragMove);
+      handle.removeEventListener("touchend", handleDragEnd);
+      handle.removeEventListener("touchcancel", handleDragEnd);
+    };
+  };
+
+  const stopStartHandle = attachHandle(startHandle);
+  const stopEndHandle = attachHandle(endHandle);
+
+  const stopToolbarEvent = (event: Event) => event.stopPropagation();
+  toolbar.addEventListener("touchstart", stopToolbarEvent);
+  toolbar.addEventListener("mousedown", stopToolbarEvent);
+
+  copyButton.addEventListener("click", () => {
+    const selection = terminal.getSelection();
+    if (selection) void toCopy(selection);
+    clearSelection();
+  });
+
+  pasteButton.addEventListener("click", async () => {
+    if (!canPaste()) return;
+    if (!navigator.clipboard?.readText) {
+      message.error(t("TXT_CODE_ca07c84c"));
+      return;
+    }
+    try {
+      const text = await navigator.clipboard.readText();
+      if (text) terminal.paste(text);
+      clearSelection();
+    } catch (error: any) {
+      if (error?.name === "NotAllowedError") {
+        message.error(t("TXT_CODE_2a22c2ff"));
+      } else {
+        message.error(error?.message ?? t("TXT_CODE_ca07c84c"));
+      }
+    }
+  });
+
+  cancelButton.addEventListener("click", clearSelection);
+
+  element.addEventListener("touchstart", handleTouchStart, { capture: true, passive: true });
+  element.addEventListener("touchmove", handleTouchMove, { capture: true, passive: false });
+  element.addEventListener("touchend", handleTouchEnd, { capture: true, passive: true });
+  element.addEventListener("touchcancel", handleTouchCancel, { capture: true, passive: true });
+  element.addEventListener("mousedown", handleCompatibilityMouseDown, true);
+  element.addEventListener("contextmenu", handleContextMenu, true);
+  document.addEventListener("touchstart", handleDocumentTouchStart, {
+    capture: true,
+    passive: true
+  });
+
+  const writeDisposable = terminal.onWriteParsed(() => {
+    if (selectionActive && trackedSelection) {
+      const { viewportMarker, startMarker, endMarker, startColumn, endColumn } = trackedSelection;
+      if (viewportMarker.line < 0 || startMarker.line < 0 || endMarker.line < 0) {
+        clearSelection();
+        return;
+      }
+
+      const nextSelectionStart = startMarker.line * terminal.cols + startColumn;
+      const nextSelectionEnd = endMarker.line * terminal.cols + endColumn;
+      if (nextSelectionEnd <= nextSelectionStart) {
+        clearSelection();
+        return;
+      }
+
+      if (nextSelectionStart !== selectionStart || nextSelectionEnd !== selectionEnd) {
+        selectionStart = nextSelectionStart;
+        selectionEnd = nextSelectionEnd;
+        terminal.select(
+          selectionStart % terminal.cols,
+          Math.floor(selectionStart / terminal.cols),
+          selectionEnd - selectionStart
+        );
+      }
+
+      selectionViewportY = viewportMarker.line;
+      if (terminal.buffer.active.viewportY !== selectionViewportY) {
+        terminal.scrollToLine(selectionViewportY);
+      }
+    } else if (
+      selectionActive &&
+      selectionViewportY !== undefined &&
+      terminal.buffer.active.viewportY !== selectionViewportY
+    ) {
+      terminal.scrollToLine(selectionViewportY);
+    }
+    scheduleSelectionUiUpdate();
+  });
+  const resizeDisposable = terminal.onResize(() => {
+    if (selectionActive) clearSelection();
+  });
+  const scrollDisposable = terminal.onScroll(scheduleSelectionUiUpdate);
+  const selectionDisposable = terminal.onSelectionChange(() => {
+    if (selectionActive && !terminal.hasSelection()) clearSelection();
+  });
+
+  return () => {
+    resetTouchState();
+    stopInertia();
+    clearSelection();
+    if (uiUpdateFrame !== undefined) cancelAnimationFrame(uiUpdateFrame);
+    stopStartHandle();
+    stopEndHandle();
+    writeDisposable.dispose();
+    resizeDisposable.dispose();
+    scrollDisposable.dispose();
+    selectionDisposable.dispose();
+    toolbar.removeEventListener("touchstart", stopToolbarEvent);
+    toolbar.removeEventListener("mousedown", stopToolbarEvent);
+    element.removeEventListener("touchstart", handleTouchStart, true);
+    element.removeEventListener("touchmove", handleTouchMove, true);
+    element.removeEventListener("touchend", handleTouchEnd, true);
+    element.removeEventListener("touchcancel", handleTouchCancel, true);
+    element.removeEventListener("mousedown", handleCompatibilityMouseDown, true);
+    element.removeEventListener("contextmenu", handleContextMenu, true);
+    document.removeEventListener("touchstart", handleDocumentTouchStart, true);
+    element.classList.remove("xterm-touch-host", "touch-selection-active", "touch-scrolling");
+    selectionUi.remove();
+  };
+}


### PR DESCRIPTION
修复在某些情况下上传文件后必须手动点刷新的问题
修复上传初始化失败时（如空间不足）不会主动终止任务 文件列表中出现不存在的文件后又无法删除
优化实例页面触摸屏设备操作手感，触摸屏设备操作终端时现在可直接长按选区复制和上下滑动