### PR TITLE
fix: reset all market filters

### DIFF
--- a/frontend/src/hooks/useMarketPackages.test.ts
+++ b/frontend/src/hooks/useMarketPackages.test.ts
@@ -1,0 +1,28 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import { resetSearchForm, type SearchForm } from "./useMarketPackages";
+
+describe("resetSearchForm", () => {
+  it("clears every market filter", () => {
+    const form: SearchForm = {
+      language: "zh_cn",
+      category: "survival",
+      gameType: "minecraft",
+      platform: "Windows",
+      keyword: "paper",
+      isSupportDocker: true,
+      system: "win"
+    };
+
+    resetSearchForm(form);
+
+    expect(form).toMatchObject({
+      language: "ALL",
+      category: "ALL",
+      gameType: "ALL",
+      platform: "ALL",
+      keyword: ""
+    });
+  });
+});

--- a/frontend/src/hooks/useMarketPackages.ts
+++ b/frontend/src/hooks/useMarketPackages.ts
@@ -29,6 +29,14 @@ export interface UseMarketPackagesOptions {
   onlyDockerTemplate?: boolean;
 }
 
+export const resetSearchForm = (searchForm: SearchForm) => {
+  searchForm.language = SEARCH_ALL_KEY;
+  searchForm.gameType = SEARCH_ALL_KEY;
+  searchForm.category = SEARCH_ALL_KEY;
+  searchForm.platform = SEARCH_ALL_KEY;
+  searchForm.keyword = "";
+};
+
 /**
  * Composable for market packages filtering and search functionality
  */
@@ -236,11 +244,7 @@ export function useMarketPackages(options: UseMarketPackagesOptions = {}) {
 
   // Handler functions
   const handleReset = () => {
-    searchForm.language = SEARCH_ALL_KEY;
-    searchForm.gameType = SEARCH_ALL_KEY;
-    searchForm.category = SEARCH_ALL_KEY;
-    // searchForm.platform = SEARCH_ALL_KEY;
-    searchForm.keyword = "";
+    resetSearchForm(searchForm);
   };
 
   const handleGameTypeChange = () => {


### PR DESCRIPTION
The market reset action clears the language, game type, category, and keyword filters, but leaves the platform filter unchanged. This can make the reset result depend on a previous platform selection.

Route the reset through a small helper that clears every search field and add a regression test for the platform field.

This is independent of the open template-language fallback issue; no issue is auto-closed by this PR.