### PR TITLE
fix: preserve custom Docker workspace paths

### DIFF
--- a/daemon/src/service/docker_process_service.ts
+++ b/daemon/src/service/docker_process_service.ts
@@ -12,6 +12,7 @@ import path from "path";
 import { EventEmitter } from "stream";
 import { IInstanceProcess } from "../entity/instance/interface";
 import { $t } from "../i18n";
+import { resolveDockerWorkspacePath } from "../tools/docker_workspace_path";
 import { AsyncTask } from "./async_task_service";
 import logger from "./log";
 import { NetworkLimitService } from "./network_limit_service";
@@ -341,9 +342,7 @@ export class SetupDockerContainer extends AsyncTask {
     let cwd = instance.absoluteCwdPath();
     const defaultInstanceDir = InstanceSubsystem.getInstanceDataDir();
     const hostRealPath = toText(process.env.MCSM_DOCKER_WORKSPACE_PATH);
-    if (hostRealPath && cwd.includes(defaultInstanceDir)) {
-      cwd = path.normalize(path.join(hostRealPath, instance.instanceUuid));
-    }
+    cwd = resolveDockerWorkspacePath(cwd, defaultInstanceDir, hostRealPath);
 
     const mounts: Docker.MountConfig = [];
     for (const v of extraBinds) {

--- a/daemon/src/tools/docker_workspace_path.ts
+++ b/daemon/src/tools/docker_workspace_path.ts
@@ -1,0 +1,20 @@
+import path from "path";
+
+export function resolveDockerWorkspacePath(
+  cwd: string,
+  defaultInstanceDir: string,
+  hostWorkspacePath: string | null
+) {
+  if (!hostWorkspacePath) return cwd;
+
+  const relativePath = path.relative(defaultInstanceDir, cwd);
+  if (
+    relativePath === ".." ||
+    relativePath.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativePath)
+  ) {
+    return cwd;
+  }
+
+  return path.normalize(path.join(hostWorkspacePath, relativePath));
+}


### PR DESCRIPTION
Fixes #2342

When MCSM_DOCKER_WORKSPACE_PATH is set, preserve the instance working directory relative to the configured default instance directory instead of replacing it with only the instance UUID.

This keeps custom instance paths working in Docker while leaving paths outside the default instance directory unchanged.

Validation:
- daemon TypeScript check passes
- focused path mapping regression cases pass